### PR TITLE
docs: add knowledge content workflow for ML notes

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -43,13 +43,24 @@ cache-aside-pattern.mdx
 
 Use `.md` for straightforward prose. Use `.mdx` when the note benefits from math, interactive components, or richer site presentation.
 
+## Categories
+
+Use one of these categories for new notes:
+
+- `DSA` for data structures, algorithms, patterns, and complexity.
+- `Machine Learning` for model foundations, implementations, evaluation, and ML systems.
+- `System Design` for architecture, scaling, reliability, and trade-offs.
+
 ## Frontmatter for New Notes
 
-Add minimal frontmatter to new notes:
+Start from [`templates/note.md`](../templates/note.md). New published notes should include:
 
 ```yaml
 ---
 title: Binary Search Invariants
+description: The decision rule and boundary handling behind binary search.
+category: DSA
+order: 10
 status: wip
 tags:
   - dsa
@@ -57,4 +68,4 @@ tags:
 ---
 ```
 
-Use `status: wip` while developing a note and `status: stable` once it is ready to rely on as a reference. Keep tags specific enough to support future navigation and discovery.
+Use `status: wip` while developing a note and `status: stable` once it is ready to rely on as a reference. Keep tags specific enough to support future navigation and discovery. `order` is optional; use it when notes in the same category need a deliberate reading sequence.

--- a/notes/README.md
+++ b/notes/README.md
@@ -53,7 +53,7 @@ Use one of these categories for new notes:
 
 ## Frontmatter for New Notes
 
-Start from [`templates/note.md`](../templates/note.md). New published notes should include:
+Start from [`templates/note.md`](https://github.com/whanyu1212/mental-gym/blob/develop/templates/note.md). New published notes should include:
 
 ```yaml
 ---

--- a/notes/ml-logistic-regression.md
+++ b/notes/ml-logistic-regression.md
@@ -1,0 +1,130 @@
+---
+title: Logistic Regression from Scratch
+description: Build a binary classifier with a vectorized forward pass, binary cross-entropy, and gradient descent.
+category: Machine Learning
+order: 10
+status: stable
+tags:
+  - machine-learning
+  - classification
+  - optimization
+  - numpy
+---
+
+# Logistic Regression from Scratch
+
+Logistic regression turns a linear score into the probability that an example belongs to the positive class. It is a small model with a complete machine-learning loop: define an objective, compute predictions, derive gradients, update parameters, and validate the result.
+
+## Intuition
+
+For each example, start with a weighted sum of features:
+
+$$
+z = Xw + b
+$$
+
+where $X$ contains examples by rows, $w$ is one weight per feature, and $b$ is a scalar bias. The sigmoid function maps each score to a probability between zero and one:
+
+$$
+\sigma(z) = \frac{1}{1 + e^{-z}}
+$$
+
+A positive score produces a probability above $0.5$; a negative score produces one below $0.5$. The model classifies an example by comparing that probability with a configurable threshold.
+
+## Baseline and Improvement
+
+A loop that computes one score and one gradient contribution per example is useful for understanding the model, but NumPy can express the same work for an entire batch.
+
+For $n$ examples and $d$ features:
+
+- `X` has shape `(n, d)`.
+- `weights` has shape `(d,)`.
+- `X @ weights` has shape `(n,)`.
+- `bias` broadcasts over all $n$ scores.
+- `y_hat` has shape `(n,)`.
+
+The repository implementation uses this vectorized forward pass:
+
+```python
+z = X @ self.weights + self.bias
+y_hat = self._sigmoid(z)
+```
+
+That keeps the code close to the mathematical definition while avoiding unnecessary Python loops over examples.
+
+## Objective and Gradients
+
+For binary labels $y \in \{0, 1\}$ and predicted probabilities $\hat{y}$, binary cross-entropy penalizes confident incorrect predictions:
+
+$$
+L = -\frac{1}{n} \sum_{i=1}^{n}
+\left(y_i \log(\hat{y}_i) + (1-y_i)\log(1-\hat{y}_i)\right)
+$$
+
+The gradient of this objective with respect to the weights and bias is:
+
+$$
+dw = \frac{1}{n} X^T(\hat{y} - y)
+$$
+
+$$
+db = \frac{1}{n} \sum_{i=1}^{n}(\hat{y}_i - y_i)
+$$
+
+The update rule moves parameters in the direction that reduces loss:
+
+```python
+self.weights -= self.learning_rate * dw
+self.bias -= self.learning_rate * db
+```
+
+## Invariant and Correctness
+
+Each gradient-descent iteration maintains a consistent parameter state: `weights` has one value per input feature and `bias` remains scalar. The forward pass produces exactly one predicted probability per training example, so the residual vector `y_hat - y` also has shape `(n,)`.
+
+Multiplying `X.T` with that residual sums each feature's contribution to the current error. A positive gradient means increasing that parameter would increase loss locally, so subtracting the gradient moves the parameter toward lower loss for a sufficiently small learning rate.
+
+## Numerical Stability
+
+Directly evaluating `np.exp(-z)` can overflow when the magnitude of `z` is large. The implementation clips logits before applying sigmoid:
+
+```python
+z = np.clip(z, -250, 250)
+return 1 / (1 + np.exp(-z))
+```
+
+If you explicitly compute binary cross-entropy, also clip probabilities away from exactly zero and one before taking logarithms. For more advanced models, use stable log-sum-exp formulations rather than relying on clipping alone.
+
+## Complexity
+
+Each training iteration performs matrix-vector products involving $n$ examples and $d$ features:
+
+- Time: $O(nd)$ per iteration.
+- Extra working space: $O(n)$ for scores, probabilities, and residuals, excluding the input matrix.
+
+With `num_iterations` iterations, total training time is $O(\text{num_iterations} \cdot n d)$.
+
+## Implementation Notes
+
+The local [`LogisticRegression`](https://github.com/whanyu1212/mental-gym/blob/main/src/ml/logistic_regression.py) class follows a familiar estimator interface:
+
+- `fit(X, y)` initializes parameters and runs gradient descent.
+- `predict_proba(X)` returns one probability per example.
+- `predict(X, threshold=0.5)` returns hard binary labels.
+
+Its smoke test creates a synthetic classification dataset, uses a deterministic train/test split, trains the model, and reports test accuracy. That is a useful first validation, but it should not replace checking loss behavior, data leakage, class balance, calibration, and metrics appropriate to the problem.
+
+## Edge Cases and Pitfalls
+
+- Ensure labels are encoded as zero and one before using the binary objective.
+- Verify that `X` is two-dimensional and that its feature count matches `weights`.
+- Keep `y` aligned with the first dimension of `X`; accidental broadcasting can hide shape mistakes.
+- Feature scaling often makes gradient descent converge more reliably.
+- Accuracy alone can be misleading for imbalanced classes; examine precision, recall, F1, or calibration when relevant.
+- The default $0.5$ threshold is a decision rule, not a universal optimum.
+
+## Related Practice
+
+- [Logistic Regression from Scratch prompt](../../machine-learning/logistic-regression-from-scratch/)
+- [Repository implementation](https://github.com/whanyu1212/mental-gym/blob/main/src/ml/logistic_regression.py)
+- [ML engineering hub](../../machine-learning/)

--- a/templates/note.md
+++ b/templates/note.md
@@ -1,0 +1,41 @@
+---
+title: Topic Title
+description: One sentence describing the concept and why it matters.
+category: DSA
+order: 10
+status: wip
+tags:
+  - topic
+---
+
+# Topic Title
+
+## Intuition
+
+Explain the problem this concept solves and the mental model to retain.
+
+## Baseline and Improvement
+
+Describe the simple approach first, where its cost comes from, and the key observation that enables a better approach.
+
+## Invariant or Correctness
+
+State the condition that remains true throughout the algorithm or process. Explain why it establishes correctness.
+
+## Complexity
+
+State and justify time and space complexity.
+
+## Implementation Notes
+
+Document important API contracts, data shapes, state transitions, or language-specific details.
+
+## Edge Cases and Pitfalls
+
+List the failures that are easy to miss and how to test for them.
+
+## Related Practice
+
+- Problem: [Practice prompt](/problems)
+- Implementation: [Source file](../src/path/to/implementation.py)
+- Related note: [Another concept](/notes/another-concept)

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -8,6 +8,8 @@ const notes = defineCollection({
     description: z.string().optional(),
     category: z.string().default("General"),
     order: z.number().optional(),
+    status: z.enum(["wip", "stable"]).optional(),
+    tags: z.array(z.string()).optional(),
   }),
 });
 

--- a/web/src/pages/machine-learning/index.astro
+++ b/web/src/pages/machine-learning/index.astro
@@ -11,7 +11,7 @@ const categories = [...new Set(mlProblems.map((problem) => problem.category))];
 		<p>ML engineering</p>
 		<h1>Implement the ideas, not just the APIs.</h1>
 		<p>Practice model fundamentals, evaluation, and production-minded ML coding through guided prompts and from-scratch implementations.</p>
-		<a href={withBase("/notes")}>Browse knowledge notes <span>→</span></a>
+		<a href={withBase("/notes/ml-logistic-regression/")}>Read: Logistic Regression from Scratch <span>→</span></a>
 	</section>
 
 	<section class="principles">


### PR DESCRIPTION
## TL;DR

Establishes a reusable knowledge-content workflow and adds the first complete ML concept-to-code-to-practice note.

## Knowledge workflow

- Adds a reusable `templates/note.md` with structured sections for intuition, correctness, complexity, implementation details, pitfalls, and related practice.
- Documents note categories, frontmatter, ordering, status, tags, and template usage in `notes/README.md`.
- Extends the notes content schema with optional `status` and `tags` metadata while retaining compatibility with existing notes.

## First ML knowledge artifact

- Adds a Logistic Regression from Scratch note covering the vectorized forward pass, binary cross-entropy, gradients, numerical stability, complexity, and validation considerations.
- Links the note to the existing repository implementation and ML practice prompt.
- Adds a direct link from the ML engineering landing page to the new note.

## Testing

- `poetry run pytest -q`
- `npm run build` from `web/`

## Intentional exclusions

- The untracked `.adal/` coaching skills are intentionally not included in this pull request.

🌸 Generated with [AdaL](https://github.com/adal-cli/)