### PR TITLE
feat(notes): surface discovery and trust metadata

### DIFF
--- a/notes/arrays_and_hashing.mdx
+++ b/notes/arrays_and_hashing.mdx
@@ -3,6 +3,11 @@ title: Arrays & Hashing
 description: Core patterns, data structures, and decision frameworks for the Arrays & Hashing topic in NeetCode 250.
 category: Patterns
 order: 1
+status: stable
+tags:
+  - dsa
+  - arrays
+  - hashing
 ---
 
 import PatternVizModal from '../web/src/components/notes/PatternVizModal.astro';

--- a/notes/asymptotic-analysis.md
+++ b/notes/asymptotic-analysis.md
@@ -2,6 +2,12 @@
 title: Asymptotic Analysis
 description: How algorithm complexity is measured and reasoned about — Big O, Omega, Theta, recurrences, the Master Theorem, and space analysis.
 category: Complexity
+order: 1
+status: stable
+tags:
+  - complexity
+  - asymptotic-analysis
+  - big-o
 ---
 
 # Asymptotic Analysis

--- a/notes/prefix_sum_pattern.md
+++ b/notes/prefix_sum_pattern.md
@@ -3,6 +3,11 @@ title: Prefix Sum Pattern
 description: A guide to the Prefix Sum pattern for efficient range sum queries in 1D, 2D, and 3D arrays.
 category: Patterns
 order: 2
+status: stable
+tags:
+  - dsa
+  - prefix-sum
+  - range-queries
 ---
 
 # Prefix Sum Pattern

--- a/notes/python-big-o-cheatsheet.md
+++ b/notes/python-big-o-cheatsheet.md
@@ -2,6 +2,12 @@
 title: Python Big O Cheatsheet
 description: A quick reference for the time complexity of common Python operations across Lists, Dictionaries, Sets, Strings, Deques, and Heaps.
 category: Languages
+order: 1
+status: stable
+tags:
+  - python
+  - complexity
+  - reference
 ---
 
 # Python Big O Cheatsheet

--- a/notes/python_builtins_for_leetcode.md
+++ b/notes/python_builtins_for_leetcode.md
@@ -2,6 +2,12 @@
 title: Python Built-in Functions & Operators for LeetCode
 description: A comprehensive reference of Python built-in functions, data structures, and libraries commonly used in LeetCode problems.
 category: Languages
+order: 2
+status: stable
+tags:
+  - python
+  - leetcode
+  - reference
 ---
 
 # Python Built-in Functions & Operators for LeetCode

--- a/notes/space-complexity-questions.md
+++ b/notes/space-complexity-questions.md
@@ -2,6 +2,12 @@
 title: Space Complexity Questions for DSA Assessments
 description: A collection of common space complexity interview questions, patterns, and Python-specific memory considerations.
 category: Complexity
+order: 5
+status: stable
+tags:
+  - complexity
+  - interview-prep
+  - memory
 ---
 
 # Space Complexity Questions for DSA Assessments

--- a/notes/space-complexity.md
+++ b/notes/space-complexity.md
@@ -2,6 +2,12 @@
 title: Space Complexity
 description: A systematic guide to space complexity — auxiliary vs total space, sources of memory usage, the call stack, data structure costs, and the time-space trade-off.
 category: Complexity
+order: 3
+status: stable
+tags:
+  - complexity
+  - space-complexity
+  - memory
 ---
 
 # Space Complexity

--- a/notes/time-complexity.md
+++ b/notes/time-complexity.md
@@ -2,6 +2,12 @@
 title: Time Complexity
 description: A systematic guide to analysing and recognising time complexity — data structure operations, sorting, graph algorithms, recurrence patterns, and interview strategy.
 category: Complexity
+order: 2
+status: stable
+tags:
+  - complexity
+  - big-o
+  - algorithms
 ---
 
 # Time Complexity

--- a/notes/time_complexity_interview_questions.md
+++ b/notes/time_complexity_interview_questions.md
@@ -2,6 +2,12 @@
 title: Time Complexity Interview Questions & Cheat Sheet
 description: A comprehensive guide to time complexity analysis for DSA interviews, covering common questions, patterns, and quick reference tables.
 category: Complexity
+order: 4
+status: stable
+tags:
+  - complexity
+  - interview-prep
+  - big-o
 ---
 
 # Time Complexity Interview Questions & Cheat Sheet

--- a/notes/two_pointers.mdx
+++ b/notes/two_pointers.mdx
@@ -2,7 +2,12 @@
 title: Two Pointers
 description: Core patterns, decision frameworks, and animations for the Two Pointers topic in NeetCode 250.
 category: Patterns
-order: 2
+order: 3
+status: stable
+tags:
+  - dsa
+  - two-pointers
+  - arrays
 ---
 
 import PatternVizModal from '../web/src/components/notes/PatternVizModal.astro';

--- a/web/src/pages/notes/[slug].astro
+++ b/web/src/pages/notes/[slug].astro
@@ -26,6 +26,13 @@ const { Content } = await render(note);
 		<span>{note.data.title}</span>
 	</nav>
 
+	{(note.data.status === "wip" || (note.data.tags && note.data.tags.length > 0)) && (
+		<div class="note-meta">
+			{note.data.status === "wip" && <span class="status">WIP</span>}
+			{note.data.tags && note.data.tags.map((tag) => <span class="tag">{tag}</span>)}
+		</div>
+	)}
+
 	<article class="prose">
 		<Content />
 		{note.id === "asymptotic-analysis" && (
@@ -75,6 +82,30 @@ const { Content } = await render(note);
 
 	.sep {
 		opacity: 0.4;
+	}
+
+	.note-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		margin: 0 0 1.5rem;
+	}
+
+	.status,
+	.tag {
+		border: 1px solid var(--border);
+		border-radius: var(--radius-pill);
+		color: var(--muted);
+		font: var(--fs-micro) var(--font-sans);
+		letter-spacing: 0.04em;
+		padding: 0.2rem 0.55rem;
+		text-transform: uppercase;
+	}
+
+	.status {
+		border-color: color-mix(in srgb, var(--status-medium) 45%, transparent);
+		color: var(--status-medium);
+		font-weight: 600;
 	}
 
 	.chart-section {

--- a/web/src/pages/notes/index.astro
+++ b/web/src/pages/notes/index.astro
@@ -5,7 +5,7 @@ import { withBase } from "../../lib/url";
 import { readingTimeMinutes } from "../../lib/readingTime";
 import ResumeRow from "../../components/ResumeRow.astro";
 
-const allNotes = await getCollection("notes");
+const allNotes = (await getCollection("notes")).filter((note) => note.data.category !== "Meta");
 
 // Explicit, pedagogical category order (foundational → reusable → reference),
 // mirroring ALGO_GROUP_ORDER in problems/index.astro. Any category not listed
@@ -43,8 +43,16 @@ const notesByCategory = categories.map((category) => ({
 					{category.notes.map((note) => (
 						<a href={withBase(`/notes/${note.id}/`)} class="note-card">
 							<div class="note-content">
-								<h3 class="note-title">{note.data.title}</h3>
+								<div class="note-heading">
+									<h3 class="note-title">{note.data.title}</h3>
+									{note.data.status === "wip" && <span class="status">WIP</span>}
+								</div>
 								{note.data.description && <p class="note-description">{note.data.description}</p>}
+								{note.data.tags && note.data.tags.length > 0 && (
+									<ul class="tag-list" aria-label="Topics">
+										{note.data.tags.map((tag) => <li>{tag}</li>)}
+									</ul>
+								)}
 							</div>
 							<div class="note-footer">
 								<span class="read-time">{readingTimeMinutes(note.body)} min read</span>
@@ -163,12 +171,31 @@ const notesByCategory = categories.map((category) => ({
 		opacity: 1;
 	}
 
+	.note-heading {
+		display: flex;
+		align-items: start;
+		gap: 0.75rem;
+		margin-bottom: 0.75rem;
+	}
+
 	.note-title {
-		margin: 0 0 0.75rem;
+		margin: 0;
 		font-size: var(--fs-xl);
 		color: var(--text);
 		font-family: var(--font-serif);
 		line-height: 1.3;
+		flex: 1;
+	}
+
+	.status {
+		border: 1px solid color-mix(in srgb, var(--status-medium) 45%, transparent);
+		border-radius: var(--radius-pill);
+		color: var(--status-medium);
+		font: 600 var(--fs-micro) var(--font-sans);
+		letter-spacing: 0.08em;
+		padding: 0.2rem 0.45rem;
+		text-transform: uppercase;
+		white-space: nowrap;
 	}
 
 	.note-description {
@@ -180,6 +207,25 @@ const notesByCategory = categories.map((category) => ({
 		-webkit-line-clamp: 3;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
+	}
+
+	.tag-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		list-style: none;
+		margin: 1rem 0 0;
+		padding: 0;
+	}
+
+	.tag-list li {
+		background: color-mix(in srgb, var(--accent) 9%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+		border-radius: var(--radius-pill);
+		color: var(--muted);
+		font: var(--fs-micro) var(--font-sans);
+		letter-spacing: 0.04em;
+		padding: 0.18rem 0.5rem;
 	}
 
 	.note-footer {


### PR DESCRIPTION
## TL;DR

Surfaces note maturity and topic metadata so the knowledge base is easier to scan, trust, and follow.

## Discovery experience

- Shows tag pills on note cards and note detail pages.
- Displays a WIP badge only for notes marked as in progress.
- Keeps the organizational notes document out of the public discovery grid.

## Metadata backfill

- Adds intentional reading order, stable status, and focused tags to the existing Complexity, Patterns, and Languages notes.
- Preserves note bodies, categories, and URLs.

## Testing

- `poetry run pytest -q`
- `npm run build` from `web/`

## Intentional exclusions

- The untracked `.adal/` coaching skills are intentionally not included in this pull request.

🌸 Generated with [AdaL](https://github.com/adal-cli/)