### PR TITLE
feat(progress): add local analytics dashboard

### DIFF
--- a/web/src/components/ProgressSummary.astro
+++ b/web/src/components/ProgressSummary.astro
@@ -1,0 +1,388 @@
+---
+import { withBase } from "../lib/url";
+
+interface Props {
+  detailed?: boolean;
+}
+
+const { detailed = false } = Astro.props;
+---
+
+<progress-summary data-detailed={detailed ? "true" : "false"}>
+  <section class:list={["progress-panel", { detailed }]}>
+    <div class="progress-loading">Loading local progress…</div>
+
+    <div class="progress-empty" hidden>
+      <h2>No review progress yet</h2>
+      <p>Rate a problem after practicing it to start building your local dashboard.</p>
+      <a href={withBase("/problems")}>Start practicing <span>→</span></a>
+    </div>
+
+    <div class="progress-content" hidden>
+      <div class="metric-grid">
+        <article>
+          <strong data-metric="reviewed">0</strong>
+          <span>Reviewed</span>
+        </article>
+        <article>
+          <strong data-metric="learning">0</strong>
+          <span>Learning</span>
+        </article>
+        <article>
+          <strong data-metric="established">0</strong>
+          <span>Established</span>
+        </article>
+        <article>
+          <strong data-metric="due">0</strong>
+          <span>Due today</span>
+        </article>
+        <article>
+          <strong class="overdue" data-metric="overdue">0</strong>
+          <span>Overdue</span>
+        </article>
+      </div>
+
+      <div class="compact-footer" hidden={detailed}>
+        <p>Established means at least three consecutive successful recalls with a review interval of seven days or more.</p>
+        <a href={withBase("/progress")}>View full progress <span>→</span></a>
+      </div>
+
+      {detailed && (
+        <div class="details">
+          <section>
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Coverage</p>
+                <h2>By domain</h2>
+              </div>
+            </div>
+            <div class="breakdown-list" data-domain-list></div>
+          </section>
+
+          <section>
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Focus areas</p>
+                <h2>By topic</h2>
+              </div>
+            </div>
+            <div class="breakdown-list" data-topic-list></div>
+          </section>
+
+          <section>
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Act now</p>
+                <h2>Review queue</h2>
+              </div>
+            </div>
+            <div class="review-list" data-review-list></div>
+            <p class="queue-empty" data-queue-empty hidden>Nothing is due. Your next reviews are scheduled for later.</p>
+          </section>
+        </div>
+      )}
+    </div>
+  </section>
+</progress-summary>
+
+<script>
+  import { withBase } from "../lib/url";
+  import { getAllRecords } from "../scripts/sr-db";
+  import { summarizeProgress } from "../scripts/sr-stats";
+  import { todayISO } from "../scripts/sr-scheduler";
+
+  const escapeHtml = (value: string) =>
+    value.replace(
+      /[&<>"']/g,
+      (character) =>
+        ({
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#039;",
+        })[character] ?? character
+    );
+
+  class ProgressSummaryElement extends HTMLElement {
+    connectedCallback() {
+      this.render();
+      window.addEventListener("mental-gym:progress-updated", this.render);
+    }
+
+    disconnectedCallback() {
+      window.removeEventListener("mental-gym:progress-updated", this.render);
+    }
+
+    render = async () => {
+      const loading = this.querySelector<HTMLElement>(".progress-loading");
+      const empty = this.querySelector<HTMLElement>(".progress-empty");
+      const content = this.querySelector<HTMLElement>(".progress-content");
+
+      try {
+        const records = await getAllRecords();
+        const stats = summarizeProgress(records, todayISO());
+
+        if (loading) loading.hidden = true;
+
+        if (stats.reviewed === 0) {
+          if (empty) empty.hidden = false;
+          if (content) content.hidden = true;
+          return;
+        }
+
+        if (empty) empty.hidden = true;
+        if (content) content.hidden = false;
+
+        for (const metric of ["reviewed", "learning", "established", "due", "overdue"] as const) {
+          const element = this.querySelector<HTMLElement>(`[data-metric="${metric}"]`);
+          if (element) element.textContent = String(stats[metric]);
+        }
+
+        if (this.dataset.detailed !== "true") return;
+
+        const renderBreakdown = (groups: typeof stats.domains) =>
+          groups
+            .map(
+              (group) => `
+                <article class="breakdown-row">
+                  <strong>${escapeHtml(group.name)}</strong>
+                  <span>${group.reviewed} reviewed</span>
+                  <span>${group.learning} learning</span>
+                  <span>${group.established} established</span>
+                  <span class="${group.overdue > 0 ? "attention" : ""}">${group.due + group.overdue} due</span>
+                </article>
+              `
+            )
+            .join("");
+
+        const domainList = this.querySelector<HTMLElement>("[data-domain-list]");
+        const topicList = this.querySelector<HTMLElement>("[data-topic-list]");
+        if (domainList) domainList.innerHTML = renderBreakdown(stats.domains);
+        if (topicList) topicList.innerHTML = renderBreakdown(stats.topics);
+
+        const reviewList = this.querySelector<HTMLElement>("[data-review-list]");
+        const queueEmpty = this.querySelector<HTMLElement>("[data-queue-empty]");
+        if (stats.dueRecords.length === 0) {
+          if (reviewList) reviewList.innerHTML = "";
+          if (queueEmpty) queueEmpty.hidden = false;
+          return;
+        }
+
+        if (queueEmpty) queueEmpty.hidden = true;
+        if (reviewList) {
+          reviewList.innerHTML = stats.dueRecords
+            .map((record) => {
+              const path =
+                record.domain === "algorithms"
+                  ? `/algorithms/${encodeURIComponent(record.slug)}/`
+                  : `/machine-learning/${encodeURIComponent(record.slug)}/`;
+              const href = withBase(path);
+              const state = record.dueDate < todayISO() ? "Overdue" : "Due today";
+
+              return `
+                <a class="review-row" href="${href}">
+                  <span>
+                    <strong>${escapeHtml(record.title)}</strong>
+                    <small>${escapeHtml(record.group)}</small>
+                  </span>
+                  <em class="${state === "Overdue" ? "attention" : ""}">${state}</em>
+                </a>
+              `;
+            })
+            .join("");
+        }
+      } catch {
+        if (loading) loading.textContent = "Progress data is unavailable in this browser.";
+      }
+    };
+  }
+
+  if (!customElements.get("progress-summary")) {
+    customElements.define("progress-summary", ProgressSummaryElement);
+  }
+</script>
+
+<style>
+  progress-summary {
+    display: block;
+  }
+
+  .progress-panel {
+    background: var(--glass-surface);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-md);
+    box-shadow: inset 0 1px 0 var(--glass-highlight), var(--shadow-sm);
+    padding: 1.25rem;
+  }
+
+  .progress-loading,
+  .progress-empty p,
+  .compact-footer p,
+  .queue-empty {
+    color: var(--muted);
+    font: var(--fs-fine) var(--font-sans);
+  }
+
+  .progress-empty h2 {
+    font: 600 var(--fs-xl) var(--font-serif);
+    margin: 0 0 0.4rem;
+  }
+
+  .progress-empty p {
+    line-height: 1.6;
+    margin: 0 0 0.75rem;
+  }
+
+  .progress-empty a,
+  .compact-footer a {
+    color: var(--accent);
+    font: 600 var(--fs-eyebrow) var(--font-sans);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .metric-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(5, 1fr);
+  }
+
+  .metric-grid article {
+    background: color-mix(in srgb, var(--panel) 72%, transparent);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 1rem;
+  }
+
+  .metric-grid strong {
+    color: var(--text);
+    font: 600 var(--fs-display) var(--font-serif);
+  }
+
+  .metric-grid strong.overdue,
+  :global(.attention) {
+    color: var(--status-hard);
+  }
+
+  .metric-grid span {
+    color: var(--muted);
+    font: var(--fs-eyebrow) var(--font-sans);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .compact-footer {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    margin-top: 1rem;
+  }
+
+  .compact-footer p {
+    line-height: 1.5;
+    margin: 0;
+    max-width: 620px;
+  }
+
+  .details {
+    display: grid;
+    gap: 2.75rem;
+    margin-top: 3rem;
+  }
+
+  .section-heading {
+    margin-bottom: 0.9rem;
+  }
+
+  .eyebrow {
+    color: var(--accent);
+    font: 600 var(--fs-eyebrow) var(--font-sans);
+    letter-spacing: 0.14em;
+    margin: 0 0 0.35rem;
+    text-transform: uppercase;
+  }
+
+  .section-heading h2 {
+    font: 600 var(--fs-h2) var(--font-serif);
+    margin: 0;
+  }
+
+  .breakdown-list,
+  .review-list {
+    border-top: 1px solid var(--border);
+  }
+
+  :global(.breakdown-row) {
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: minmax(170px, 1.5fr) repeat(4, minmax(80px, 1fr));
+    padding: 0.8rem 0;
+  }
+
+  :global(.breakdown-row) strong,
+  :global(.review-row) strong {
+    color: var(--text);
+    font: 600 var(--fs-base) var(--font-serif);
+  }
+
+  :global(.breakdown-row) span {
+    color: var(--muted);
+    font: var(--fs-eyebrow) var(--font-sans);
+  }
+
+  :global(.review-row) {
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+    padding: 0.8rem 0;
+    text-decoration: none;
+  }
+
+  :global(.review-row):hover {
+    text-decoration: none;
+  }
+
+  :global(.review-row) > span {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  :global(.review-row) small,
+  :global(.review-row) em {
+    color: var(--muted);
+    font: normal var(--fs-eyebrow) var(--font-sans);
+  }
+
+  .queue-empty {
+    margin: 0.75rem 0 0;
+  }
+
+  @media (max-width: 720px) {
+    .metric-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    :global(.breakdown-row) {
+      align-items: start;
+      grid-template-columns: 1fr 1fr;
+    }
+
+    :global(.breakdown-row) strong {
+      grid-column: 1 / -1;
+    }
+
+    .compact-footer {
+      align-items: start;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/web/src/components/RecallRating.astro
+++ b/web/src/components/RecallRating.astro
@@ -98,6 +98,7 @@ const { domain, slug, title, difficulty, group } = Astro.props;
 
           const updated = schedule(record, quality);
           await putRecord(updated);
+          window.dispatchEvent(new CustomEvent("mental-gym:progress-updated"));
 
           // Disable buttons, show result
           buttons.forEach((b) => (b.disabled = true));

--- a/web/src/components/SRDataManager.astro
+++ b/web/src/components/SRDataManager.astro
@@ -91,6 +91,7 @@
           const count = await importAll(text);
           showFeedback(`Imported ${count} records.`);
           await updateSummary();
+          window.dispatchEvent(new CustomEvent("mental-gym:progress-updated"));
         } catch (e: any) {
           showFeedback(`Import failed: ${e.message}`);
         }
@@ -111,6 +112,7 @@
         dialog.close();
         showFeedback("All review data cleared.");
         await updateSummary();
+        window.dispatchEvent(new CustomEvent("mental-gym:progress-updated"));
       });
     }
   }

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import DueForReview from "../components/DueForReview.astro";
+import ProgressSummary from "../components/ProgressSummary.astro";
 import ResumeRow from "../components/ResumeRow.astro";
 import { mlProblems } from "../data/mlProblems";
 import { problems } from "../data/problems";
@@ -24,6 +25,16 @@ const completedML = mlProblems.filter((problem) => problem.status === "Completed
 
 	<ResumeRow />
 
+	<section class="progress-summary">
+		<div class="section-heading">
+			<div>
+				<p class="eyebrow">Local progress</p>
+				<h2>Build durable recall</h2>
+			</div>
+		</div>
+		<ProgressSummary />
+	</section>
+
 	<section class="workflow" aria-label="Learning workflow">
 		<a class="workflow-card practice" href={withBase("/problems")}>
 			<p class="card-index">01</p>
@@ -43,7 +54,7 @@ const completedML = mlProblems.filter((problem) => problem.status === "Completed
 			<p>Return to problems on a spaced schedule and turn solved work into recall practice.</p>
 			<span class="card-link">Review queue <span>→</span></span>
 		</a>
-		<a class="workflow-card progress" href={withBase("/problems")}>
+		<a class="workflow-card progress" href={withBase("/progress")}>
 			<p class="card-index">04</p>
 			<h2>Progress</h2>
 			<p>Use the problem bank to see coverage by domain, pattern, difficulty, and learning status.</p>
@@ -131,6 +142,7 @@ const completedML = mlProblems.filter((problem) => problem.status === "Completed
 	.card-link, .domain-card span { color: var(--accent); font: 600 var(--fs-eyebrow) var(--font-sans); letter-spacing: .08em; margin-top: auto; padding-top: 1.25rem; text-transform: uppercase; }
 	.card-link span, .domain-card b, .section-heading a span { transition: transform .15s; }
 	.workflow-card:hover .card-link span, .domain-card:hover b, .section-heading a:hover span { display: inline-block; transform: translateX(4px); }
+	.progress-summary { margin: 1rem 0 3rem; }
 	.review-area, .domains, .notes { margin-top: 3.5rem; }
 	.section-heading { align-items: end; display: flex; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
 	.section-heading h2 { font-size: var(--fs-h2); margin: 0; }

--- a/web/src/pages/progress/index.astro
+++ b/web/src/pages/progress/index.astro
@@ -1,0 +1,90 @@
+---
+import ProgressSummary from "../../components/ProgressSummary.astro";
+import SRDataManager from "../../components/SRDataManager.astro";
+import Layout from "../../layouts/Layout.astro";
+import { withBase } from "../../lib/url";
+---
+
+<Layout title="Progress | Mental Gym">
+	<section class="hero">
+		<p>Local progress</p>
+		<h1>See what is becoming durable.</h1>
+		<p>Your dashboard is calculated from spaced-repetition data stored only in this browser.</p>
+		<a href={withBase("/problems")}>Continue practicing <span>→</span></a>
+	</section>
+
+	<ProgressSummary detailed={true} />
+
+	<section class="data-section">
+		<div>
+			<p class="eyebrow">Your data</p>
+			<h2>Private by default, portable by choice.</h2>
+			<p>Deployments and page refreshes do not erase progress, but another browser or device cannot see it automatically. Export a backup to transfer or preserve your review data.</p>
+		</div>
+		<SRDataManager />
+	</section>
+</Layout>
+
+<style>
+	.hero {
+		max-width: 720px;
+		padding: 3.5rem 0 2.5rem;
+	}
+
+	.hero > p:first-child,
+	.eyebrow,
+	.hero a {
+		color: var(--accent);
+		font: 600 var(--fs-eyebrow) var(--font-sans);
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	h2 {
+		font-family: var(--font-serif);
+		font-weight: 600;
+	}
+
+	h1 {
+		font-size: var(--fs-mega);
+		line-height: 1;
+		margin: 0.45rem 0 1rem;
+	}
+
+	.hero > p:not(:first-child),
+	.data-section > div > p:not(.eyebrow) {
+		color: var(--muted);
+		font-size: var(--fs-lg);
+		line-height: 1.6;
+		margin: 0 0 1.25rem;
+	}
+
+	.data-section {
+		background: var(--glass-surface);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		box-shadow: inset 0 1px 0 var(--glass-highlight), var(--shadow-sm);
+		display: grid;
+		gap: 2rem;
+		grid-template-columns: minmax(0, 1.5fr) minmax(280px, 1fr);
+		margin-top: 2rem;
+		padding: 1.5rem;
+	}
+
+	.data-section h2 {
+		font-size: var(--fs-xl);
+		margin: 0 0 0.5rem;
+	}
+
+	.data-section > div > p:not(.eyebrow) {
+		font-size: var(--fs-sm);
+		margin: 0;
+	}
+
+	@media (max-width: 720px) {
+		.data-section {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/web/src/scripts/sr-stats.ts
+++ b/web/src/scripts/sr-stats.ts
@@ -1,0 +1,84 @@
+import type { ReviewRecord } from "./sr-types";
+
+export interface ProgressBreakdown {
+  reviewed: number;
+  learning: number;
+  established: number;
+  due: number;
+  overdue: number;
+}
+
+export interface ProgressGroup extends ProgressBreakdown {
+  name: string;
+}
+
+export interface ProgressStats extends ProgressBreakdown {
+  domains: ProgressGroup[];
+  topics: ProgressGroup[];
+  dueRecords: ReviewRecord[];
+}
+
+export function isEstablished(record: ReviewRecord): boolean {
+  return record.repetitions >= 3 && record.interval >= 7;
+}
+
+function summarize(records: ReviewRecord[], today: string): ProgressBreakdown {
+  const reviewed = records.filter((record) => record.lastReviewDate !== null);
+  const established = reviewed.filter(isEstablished).length;
+
+  return {
+    reviewed: reviewed.length,
+    learning: reviewed.length - established,
+    established,
+    due: reviewed.filter((record) => record.dueDate === today).length,
+    overdue: reviewed.filter((record) => record.dueDate < today).length,
+  };
+}
+
+function groupRecords(
+  records: ReviewRecord[],
+  today: string,
+  keyOf: (record: ReviewRecord) => string
+): ProgressGroup[] {
+  const groups = new Map<string, ReviewRecord[]>();
+
+  for (const record of records) {
+    const key = keyOf(record);
+    const group = groups.get(key) ?? [];
+    group.push(record);
+    groups.set(key, group);
+  }
+
+  return [...groups.entries()]
+    .map(([name, group]) => ({ name, ...summarize(group, today) }))
+    .sort(
+      (a, b) =>
+        b.overdue - a.overdue ||
+        b.due - a.due ||
+        b.reviewed - a.reviewed ||
+        a.name.localeCompare(b.name)
+    );
+}
+
+export function summarizeProgress(
+  records: ReviewRecord[],
+  today: string
+): ProgressStats {
+  const reviewed = records.filter((record) => record.lastReviewDate !== null);
+  const dueRecords = reviewed
+    .filter((record) => record.dueDate <= today)
+    .sort(
+      (a, b) =>
+        a.dueDate.localeCompare(b.dueDate) ||
+        a.title.localeCompare(b.title)
+    );
+
+  return {
+    ...summarize(records, today),
+    domains: groupRecords(reviewed, today, (record) =>
+      record.domain === "algorithms" ? "Algorithms" : "Machine Learning"
+    ),
+    topics: groupRecords(reviewed, today, (record) => record.group),
+    dueRecords,
+  };
+}

--- a/web/tests/sr-stats.test.ts
+++ b/web/tests/sr-stats.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ReviewRecord } from "../src/scripts/sr-types.ts";
+import { isEstablished, summarizeProgress } from "../src/scripts/sr-stats.ts";
+
+const TODAY = "2026-07-13";
+
+function record(
+  overrides: Partial<ReviewRecord> & Pick<ReviewRecord, "problemKey" | "slug" | "title">
+): ReviewRecord {
+  return {
+    domain: "algorithms",
+    difficulty: "Medium",
+    group: "Arrays & Hashing",
+    easeFactor: 2.5,
+    interval: 1,
+    repetitions: 1,
+    dueDate: TODAY,
+    lastReviewDate: TODAY,
+    lastRating: 2,
+    ...overrides,
+  };
+}
+
+test("established requires three recalls and a seven-day interval", () => {
+  assert.equal(
+    isEstablished(
+      record({
+        problemKey: "algorithms:established",
+        slug: "established",
+        title: "Established",
+        repetitions: 3,
+        interval: 7,
+      })
+    ),
+    true
+  );
+
+  assert.equal(
+    isEstablished(
+      record({
+        problemKey: "algorithms:short",
+        slug: "short",
+        title: "Short interval",
+        repetitions: 3,
+        interval: 6,
+      })
+    ),
+    false
+  );
+});
+
+test("summarizes current review states", () => {
+  const stats = summarizeProgress(
+    [
+      record({
+        problemKey: "algorithms:learning",
+        slug: "learning",
+        title: "Learning",
+      }),
+      record({
+        problemKey: "algorithms:established",
+        slug: "established",
+        title: "Established",
+        repetitions: 4,
+        interval: 12,
+        dueDate: "2026-07-20",
+      }),
+      record({
+        problemKey: "ml:overdue",
+        slug: "overdue",
+        title: "Overdue",
+        domain: "ml",
+        group: "Classic ML",
+        dueDate: "2026-07-12",
+      }),
+      record({
+        problemKey: "algorithms:new",
+        slug: "new",
+        title: "Not reviewed",
+        lastReviewDate: null,
+        lastRating: null,
+      }),
+    ],
+    TODAY
+  );
+
+  assert.deepEqual(
+    {
+      reviewed: stats.reviewed,
+      learning: stats.learning,
+      established: stats.established,
+      due: stats.due,
+      overdue: stats.overdue,
+    },
+    {
+      reviewed: 3,
+      learning: 2,
+      established: 1,
+      due: 1,
+      overdue: 1,
+    }
+  );
+  assert.deepEqual(
+    stats.dueRecords.map(({ title }) => title),
+    ["Overdue", "Learning"]
+  );
+});
+
+test("groups reviewed records by domain and topic", () => {
+  const stats = summarizeProgress(
+    [
+      record({
+        problemKey: "algorithms:two-sum",
+        slug: "two-sum",
+        title: "Two Sum",
+      }),
+      record({
+        problemKey: "ml:logistic",
+        slug: "logistic",
+        title: "Logistic Regression",
+        domain: "ml",
+        group: "Classic ML",
+        repetitions: 3,
+        interval: 7,
+        dueDate: "2026-07-20",
+      }),
+    ],
+    TODAY
+  );
+
+  assert.deepEqual(
+    stats.domains.map(({ name, reviewed, established }) => ({
+      name,
+      reviewed,
+      established,
+    })),
+    [
+      { name: "Algorithms", reviewed: 1, established: 0 },
+      { name: "Machine Learning", reviewed: 1, established: 1 },
+    ]
+  );
+  assert.deepEqual(
+    stats.topics.map(({ name }) => name),
+    ["Arrays & Hashing", "Classic ML"]
+  );
+});


### PR DESCRIPTION
## TL;DR

Adds a browser-local progress dashboard that turns spaced-repetition records into actionable current-state analytics.

## Progress experience

- Adds a compact homepage summary for reviewed, learning, established, due, and overdue items.
- Adds a detailed `/progress` page with domain and topic breakdowns.
- Includes a due-review queue with direct links back to practice items.
- Defines “Established” conservatively as at least three consecutive successful recalls with an interval of seven days or more.

## Local-first data

- Computes analytics entirely from the existing IndexedDB review records.
- Keeps progress private to the browser with no backend or tracking service.
- Reuses existing export, import, and reset controls for backup and device transfer.
- Refreshes analytics immediately after ratings, imports, and resets.

## Testing

- `node --test tests/sr-stats.test.ts` — 3 tests passed
- `poetry run pytest -q` — 33 tests passed
- `npm run build` from `web/`
- Astro checker was also inspected; it reports extensive pre-existing project diagnostics, with none referencing the new progress files.

🌸 Generated with [AdaL](https://github.com/adal-cli/)