### PR TITLE
docs: polish two-pointer notes and visualizations

### DIFF
--- a/notes/two_pointers.mdx
+++ b/notes/two_pointers.mdx
@@ -423,7 +423,7 @@ def merge(nums1, m, nums2, n):
     write = m + n - 1
 
     while p1 >= 0 and p2 >= 0:
-        if nums1[p1] > nums2[p2]:
+        if nums1[p1] >= nums2[p2]:
             nums1[write] = nums1[p1]
             p1 -= 1
         else:

--- a/notes/two_pointers.mdx
+++ b/notes/two_pointers.mdx
@@ -21,48 +21,150 @@ import TrappingWaterViz from '../web/src/components/notes/TrappingWaterViz.astro
 
 # Two Pointers
 
-Two pointers is not a single trick — it is a family of techniques that all share one property: you maintain two indices into a sequence and move them according to a logical rule that guarantees correctness while visiting each element at most O(1) times. The result is usually O(n) from what would otherwise be O(n²).
+Two pointers is a family of techniques in which two positions move through one or more sequences without repeatedly revisiting the same work. The pointers may converge, move in the same direction, or belong to separate inputs.
+
+The important idea is not merely that there are two variables. Every movement must be justified by an invariant or a safe elimination rule.
 
 ---
 
 ## Table of Contents
 
-- [Why Two Pointers Works](#why-two-pointers-works)
+- [Core Mental Model](#core-mental-model)
+- [Pointer-Motion Families](#pointer-motion-families)
 - [Pattern Recognition Guide](#pattern-recognition-guide)
 - [Core Patterns](#core-patterns)
   - [1. Opposite-Ends Converging](#1-opposite-ends-converging-sorted-array)
   - [2. Palindrome Check](#2-palindrome-check--skip)
   - [3. Reverse / Rotate In-Place](#3-reverse--rotate-in-place)
-  - [4. Merge Two Sorted Sequences](#4-merge-two-sorted-sequences)
-  - [5. Write Pointer (Remove Duplicates)](#5-write-pointer-remove-duplicates)
-  - [6. K-Sum Reduction (3Sum / 4Sum)](#6-k-sum-reduction-3sum--4sum)
-  - [7. Running Max Walls (Trapping Rain Water)](#7-running-max-walls-trapping-rain-water)
-- [Decision Guide: Which Pointer Strategy?](#decision-guide-which-pointer-strategy)
+  - [4. Read/Write Pointers](#4-readwrite-pointers-in-place-filtering)
+  - [5. Merge Two Sorted Sequences](#5-merge-two-sorted-sequences)
+  - [6. K-Sum Reduction](#6-k-sum-reduction-3sum--4sum)
+  - [7. Running Max Walls](#7-running-max-walls-trapping-rain-water)
+- [Two Pointers vs. Sliding Window](#two-pointers-vs-sliding-window)
+- [Beyond Arrays: Fast/Slow Pointers](#beyond-arrays-fastslow-pointers)
+- [Common Pitfalls](#common-pitfalls)
+- [Decision Guide](#decision-guide-which-pointer-strategy)
 - [Complexity Reference](#complexity-reference)
+- [Recall Checklist](#recall-checklist)
 
 ---
 
-## Why Two Pointers Works
+## Core Mental Model
 
-Every two-pointer algorithm rests on a **monotone invariant**: moving a pointer in one direction always makes some quantity larger (or smaller). This eliminates the need to check every pair:
+Before writing code, answer three questions:
 
-> Instead of "check all combinations of i and j (O(n²))", you ask: "given the current sum/comparison, which direction must I move to get closer to the answer?"
+1. **What does each pointer represent?**
+2. **What region has already been processed?**
+3. **Why is the next pointer movement safe?**
 
-For this reasoning to work, the array is usually **sorted** (for numeric problems) or has a known structure (string symmetry, pre-allocated space). When you see "sorted array" or "in-place with O(1) space" in a problem, two pointers is the first thing to reach for.
+For sorted pair search, order makes it safe to eliminate one endpoint. For read/write filtering, the output prefix is already complete. For an in-place merge, the suffix after the write pointer is already in its final position.
+
+Two pointers often turns an O(n²) pair search into O(n), but not always:
+
+- Sorting first can make the total O(n log n).
+- 3Sum uses an outer loop plus a linear scan, so it remains O(n²).
+- The real benefit is avoiding unnecessary repeated work.
+
+If pointers move only forward or inward and never reset, they usually make at most O(n) movements in total.
+
+---
+
+## Pointer-Motion Families
+
+### A. Converging pointers
+
+Start at opposite ends and move inward.
+
+```python
+left, right = 0, len(items) - 1
+
+while left < right:
+    if should_move_left:
+        left += 1
+    else:
+        right -= 1
+```
+
+Typical uses: sorted pair search, palindrome checks, reversal, and maximum-area problems.
+
+**Invariant:** everything outside `[left, right]` has been processed or safely eliminated.
+
+### B. Read/write pointers
+
+Both move forward, but they have different jobs.
+
+```python
+write = 0
+
+for read in range(len(items)):
+    if should_keep(items[read]):
+        items[write] = items[read]
+        write += 1
+```
+
+Typical uses: remove elements, remove duplicates, move selected values, and compact an array in place.
+
+**Invariant:** `items[:write]` is the completed output built from the input examined so far.
+
+### C. One pointer per input
+
+Each pointer tracks one sequence. A separate output pointer may record where the next result belongs.
+
+```python
+i = j = 0
+
+while i < len(a) and j < len(b):
+    if a[i] <= b[j]:
+        take(a[i])
+        i += 1
+    else:
+        take(b[j])
+        j += 1
+```
+
+Typical uses: merging or intersecting sorted sequences.
+
+**Invariant:** everything before `i` and `j` has already been handled.
+
+### D. Fixed anchor plus converging pointers
+
+Fix one or more values, then use converging pointers on the remaining sorted suffix.
+
+Typical uses: 3Sum, 4Sum, and general K-sum reduction.
 
 ---
 
 ## Pattern Recognition Guide
 
-| If the problem says / constraints say… | Pattern |
+```text
+Need a pair in sorted input?
+→ Converging pointers
+
+Need to compare mirrored positions?
+→ Converging pointers
+
+Need to filter or compact an array in place?
+→ Read/write pointers
+
+Need to combine two sorted inputs?
+→ One pointer per input
+
+Need a triplet or quadruplet?
+→ Fix anchors, then converge
+
+Need the longest or shortest valid contiguous range?
+→ Probably sliding window
+```
+
+| Signal | Pattern |
 |---|---|
-| Sorted array, find pair/triplet with sum = target | [Opposite-Ends Converging](#1-opposite-ends-converging-sorted-array) |
-| Check/validate a palindrome, allow one deletion | [Palindrome Check / Skip](#2-palindrome-check--skip) |
-| Reverse a string in-place, rotate an array | [Reverse / Rotate In-Place](#3-reverse--rotate-in-place) |
-| Merge two sorted arrays/strings into one | [Merge Two Sorted Sequences](#4-merge-two-sorted-sequences) |
-| Remove duplicates from sorted array, O(1) space | [Write Pointer](#5-write-pointer-remove-duplicates) |
-| 3Sum, 4Sum — reduce to pair sum problem | [K-Sum Reduction](#6-k-sum-reduction-3sum--4sum) |
-| "Trap water", "max area", "container", running maximums | [Running Max Walls](#7-running-max-walls-trapping-rain-water) |
+| Sorted array, find pair/triplet with target sum | [Opposite-Ends Converging](#1-opposite-ends-converging-sorted-array) |
+| Validate a palindrome or allow one deletion | [Palindrome Check / Skip](#2-palindrome-check--skip) |
+| Reverse or rotate in place | [Reverse / Rotate In-Place](#3-reverse--rotate-in-place) |
+| Remove values or duplicates in place | [Read/Write Pointers](#4-readwrite-pointers-in-place-filtering) |
+| Combine two sorted inputs | [Merge Two Sorted Sequences](#5-merge-two-sorted-sequences) |
+| 3Sum or 4Sum | [K-Sum Reduction](#6-k-sum-reduction-3sum--4sum) |
+| Trap water or maintain boundaries from both sides | [Running Max Walls](#7-running-max-walls-trapping-rain-water) |
 
 ---
 
@@ -70,57 +172,67 @@ For this reasoning to work, the array is usually **sorted** (for numeric problem
 
 ### 1. Opposite-Ends Converging (sorted array)
 
-> **Signals:** sorted array, find pair/triplet summing to target, "two sum II", "container with most water", "boats to save people"
+> **Signals:** sorted array, pair sum, Two Sum II, Container With Most Water, Boats to Save People
 
 <PatternVizModal label="Opposite-Ends Converging">
   <OppositeEndsViz />
 </PatternVizModal>
 
-**The invariant:** At every step, if the answer exists it lies within `[left, right]`. We eliminate one element per step:
-- If `sum > target` → `right--` (the right value is too large; eliminate it)
-- If `sum < target` → `left++` (the left value is too small; eliminate it)
+**Invariant:** if the answer exists, it remains within `[left, right]`. Each step safely eliminates one endpoint:
+
+- If `sum > target`, move `right` because the right value is too large.
+- If `sum < target`, move `left` because the left value is too small.
 
 ```python
-# Two Sum II — sorted input, 1-indexed output
 def two_sum(numbers, target):
-    l, r = 0, len(numbers) - 1
-    while l < r:
-        s = numbers[l] + numbers[r]
-        if s == target:
-            return [l + 1, r + 1]
-        elif s < target:
-            l += 1
+    left, right = 0, len(numbers) - 1
+
+    while left < right:
+        total = numbers[left] + numbers[right]
+
+        if total == target:
+            return [left + 1, right + 1]
+        if total < target:
+            left += 1
         else:
-            r -= 1
+            right -= 1
 ```
 
-**Container With Most Water** — same converging logic, different decision rule: move the pointer with the *shorter* wall (moving the taller one can only decrease area):
+**Container With Most Water** has the same shape but a different movement rule. Move the shorter wall because it limits the current area; moving the taller wall cannot improve that limit while width decreases.
 
 ```python
 def max_area(height):
-    l, r = 0, len(height) - 1
-    res = 0
-    while l < r:
-        res = max(res, min(height[l], height[r]) * (r - l))
-        if height[l] < height[r]:
-            l += 1
+    left, right = 0, len(height) - 1
+    result = 0
+
+    while left < right:
+        result = max(
+            result,
+            min(height[left], height[right]) * (right - left),
+        )
+
+        if height[left] < height[right]:
+            left += 1
         else:
-            r -= 1
-    return res
+            right -= 1
+
+    return result
 ```
 
-**Boats to Save People** — sort first, then greedily pair heaviest with lightest:
+**Boats to Save People** sorts first, then pairs the heaviest person with the lightest when possible:
 
 ```python
 def num_rescue_boats(people, limit):
     people.sort()
-    l, r = 0, len(people) - 1
+    left, right = 0, len(people) - 1
     boats = 0
-    while l <= r:
-        if people[l] + people[r] <= limit:
-            l += 1
-        r -= 1
+
+    while left <= right:
+        if people[left] + people[right] <= limit:
+            left += 1
+        right -= 1
         boats += 1
+
     return boats
 ```
 
@@ -128,285 +240,528 @@ def num_rescue_boats(people, limit):
 
 ### 2. Palindrome Check / Skip
 
-> **Signals:** "valid palindrome", "palindrome after one deletion", skip non-alphanumeric, allow one mismatch
+> **Signals:** valid palindrome, one allowed deletion, skip non-alphanumeric characters
 
 <PatternVizModal label="Palindrome Check">
   <PalindromeCheckViz />
 </PatternVizModal>
 
-**Valid Palindrome** — skip non-alphanumeric characters, compare case-insensitively:
+Palindrome checks compare mirrored positions and shrink the unknown region from both ends.
 
 ```python
 def is_palindrome(s: str) -> bool:
-    l, r = 0, len(s) - 1
-    while l < r:
-        while l < r and not s[l].isalnum():
-            l += 1
-        while l < r and not s[r].isalnum():
-            r -= 1
-        if s[l].lower() != s[r].lower():
+    left, right = 0, len(s) - 1
+
+    while left < right:
+        while left < right and not s[left].isalnum():
+            left += 1
+        while left < right and not s[right].isalnum():
+            right -= 1
+
+        if s[left].lower() != s[right].lower():
             return False
-        l += 1
-        r -= 1
+
+        left += 1
+        right -= 1
+
     return True
 ```
 
-**Valid Palindrome II** — allow one deletion. The key: on the first mismatch, try skipping left **or** right, and check if either sub-string is a palindrome:
+**Valid Palindrome II** allows one deletion. At the first mismatch, skip either side and test the remaining range:
 
 ```python
 def valid_palindrome(s: str) -> bool:
-    def is_pal(l, r):
-        while l < r:
-            if s[l] != s[r]:
+    def is_pal(left, right):
+        while left < right:
+            if s[left] != s[right]:
                 return False
-            l += 1; r -= 1
+            left += 1
+            right -= 1
         return True
 
-    l, r = 0, len(s) - 1
-    while l < r:
-        if s[l] != s[r]:
-            return is_pal(l + 1, r) or is_pal(l, r - 1)
-        l += 1; r -= 1
+    left, right = 0, len(s) - 1
+
+    while left < right:
+        if s[left] != s[right]:
+            return (
+                is_pal(left + 1, right)
+                or is_pal(left, right - 1)
+            )
+        left += 1
+        right -= 1
+
     return True
 ```
 
-**Why this works:** A palindrome can absorb at most one bad character by deleting it from either side. The first mismatch is the only branch point.
+The first mismatch is the only branch point. Passing index boundaries rather than slices also avoids allocating new strings.
 
 ---
 
 ### 3. Reverse / Rotate In-Place
 
-> **Signals:** "reverse string in-place", "rotate array by k steps", O(1) extra space required
+> **Signals:** reverse in place, rotate by `k`, O(1) extra space
 
 <PatternVizModal label="Reverse / Rotate In-Place">
   <ReverseRotateViz />
 </PatternVizModal>
 
-**Reverse a String** — classic swap, O(n/2) steps:
-
 ```python
 def reverse_string(s: list) -> None:
-    l, r = 0, len(s) - 1
-    while l < r:
-        s[l], s[r] = s[r], s[l]
-        l += 1; r -= 1
+    left, right = 0, len(s) - 1
+
+    while left < right:
+        s[left], s[right] = s[right], s[left]
+        left += 1
+        right -= 1
 ```
 
-**Rotate Array by k** — the three-reversal trick avoids O(n) extra space:
+**Rotate Array** uses three reversals:
 
 ```python
 def rotate(nums: list, k: int) -> None:
-    k %= len(nums)          # handle k > n
+    if not nums:
+        return
 
-    def rev(l, r):
-        while l < r:
-            nums[l], nums[r] = nums[r], nums[l]
-            l += 1; r -= 1
+    k %= len(nums)
 
-    rev(0, len(nums) - 1)   # 1. reverse entire array
-    rev(0, k - 1)           # 2. reverse first k elements
-    rev(k, len(nums) - 1)   # 3. reverse remaining elements
+    def reverse(left, right):
+        while left < right:
+            nums[left], nums[right] = nums[right], nums[left]
+            left += 1
+            right -= 1
+
+    reverse(0, len(nums) - 1)
+    reverse(0, k - 1)
+    reverse(k, len(nums) - 1)
 ```
 
-**Why three reversals work:** Rotating right by k is equivalent to moving the last k elements to the front. Reversing the whole array, then reversing each half independently, achieves this without extra allocation.
+The empty-input guard prevents division by zero in `k %= len(nums)`.
 
 ---
 
-### 4. Merge Two Sorted Sequences
+### 4. Read/Write Pointers (In-Place Filtering)
 
-> **Signals:** "merge sorted array", "merge strings alternately", "two sorted inputs into one output"
-
-<PatternVizModal label="Merge Two Sequences">
-  <MergeTwoViz />
-</PatternVizModal>
-
-**Merge Sorted Array** — fill from the **back** to avoid overwriting unprocessed elements:
-
-```python
-def merge(nums1, m, nums2, n):
-    p1, p2, w = m - 1, n - 1, m + n - 1
-    while p1 >= 0 and p2 >= 0:
-        if nums1[p1] >= nums2[p2]:
-            nums1[w] = nums1[p1]; p1 -= 1
-        else:
-            nums1[w] = nums2[p2]; p2 -= 1
-        w -= 1
-    # Any remaining nums2 elements:
-    nums1[:p2 + 1] = nums2[:p2 + 1]
-```
-
-**Merge Strings Alternately** — two pointers on two strings, alternating picks:
-
-```python
-def merge_alternately(word1, word2):
-    i = j = 0
-    res = []
-    while i < len(word1) and j < len(word2):
-        res.append(word1[i]); i += 1
-        res.append(word2[j]); j += 1
-    res.append(word1[i:])
-    res.append(word2[j:])
-    return ''.join(res)
-```
-
----
-
-### 5. Write Pointer (Remove Duplicates)
-
-> **Signals:** "remove duplicates from sorted array", "remove element in-place", O(1) extra space, return new length
+> **Signals:** remove in place, compact values, move zeroes, return the new length
 
 <PatternVizModal label="Write Pointer — Remove Duplicates">
   <RemoveDupsViz />
 </PatternVizModal>
 
-The slow/fast (read/write) pattern: `fast` scans every element; `slow` only advances when a *new* unique value is found.
+- `read` examines the next input value.
+- `write` points to the next kept value’s destination.
+
+Because `write <= read`, assigning `nums[write] = nums[read]` cannot destroy unread input.
+
+**Remove Element:**
+
+```python
+def remove_element(nums, value) -> int:
+    write = 0
+
+    for read in range(len(nums)):
+        if nums[read] != value:
+            nums[write] = nums[read]
+            write += 1
+
+    return write
+```
+
+**Invariant:** `nums[:write]` contains exactly the kept values from the input examined so far.
+
+**Remove Duplicates from Sorted Array:**
 
 ```python
 def remove_duplicates(nums) -> int:
-    slow = 0
-    for fast in range(1, len(nums)):
-        if nums[fast] != nums[slow]:
-            slow += 1
-            nums[slow] = nums[fast]
-    return slow + 1
+    if not nums:
+        return 0
+
+    write = 1
+
+    for read in range(1, len(nums)):
+        if nums[read] != nums[write - 1]:
+            nums[write] = nums[read]
+            write += 1
+
+    return write
 ```
 
-**Remove Duplicates II** (allow at most 2 of each):
+**Retain at most `k` copies:**
 
 ```python
-def remove_duplicates_ii(nums) -> int:
-    slow = 0
-    for fast in range(len(nums)):
-        if slow < 2 or nums[fast] != nums[slow - 2]:
-            nums[slow] = nums[fast]
-            slow += 1
-    return slow
+def retain_at_most_k(nums, k) -> int:
+    if k <= 0:
+        return 0
+
+    write = 0
+
+    for read in range(len(nums)):
+        if write < k or nums[read] != nums[write - k]:
+            nums[write] = nums[read]
+            write += 1
+
+    return write
 ```
 
-**The generalisation:** The condition `nums[fast] != nums[slow - k + 1]` controls how many duplicates are allowed. For k=1 (no dups), compare to `nums[slow]`. For k=2, compare to `nums[slow - 1]`.
+For `k = 2`, compare the current value with the value two accepted positions behind it. If they differ, accepting the current value cannot create more than two copies.
+
+---
+
+### 5. Merge Two Sorted Sequences
+
+> **Signals:** merge sorted arrays, two ordered inputs, pre-allocated output space
+
+<PatternVizModal label="Merge Two Sequences">
+  <MergeTwoViz />
+</PatternVizModal>
+
+A normal forward merge compares the smallest unprocessed values. If the output must overwrite `nums1`, writing from the front can destroy values that have not been compared. Fill from the back instead:
+
+```python
+def merge(nums1, m, nums2, n):
+    p1 = m - 1
+    p2 = n - 1
+    write = m + n - 1
+
+    while p1 >= 0 and p2 >= 0:
+        if nums1[p1] > nums2[p2]:
+            nums1[write] = nums1[p1]
+            p1 -= 1
+        else:
+            nums1[write] = nums2[p2]
+            p2 -= 1
+
+        write -= 1
+
+    while p2 >= 0:
+        nums1[write] = nums2[p2]
+        p2 -= 1
+        write -= 1
+```
+
+The pointers mean:
+
+```text
+p1    last unmerged real value in nums1
+p2    last unmerged value in nums2
+write next destination slot in nums1
+```
+
+This is often called a two-pointer solution even though it contains three pointer variables: `p1` and `p2` make the merge decision, while `write` tracks the output position.
+
+**Invariant:** everything to the right of `write` is already in its final sorted position.
+
+```text
+nums1 = [10, 20, 20, 40, 0, 0], m = 4
+nums2 = [1, 2],                  n = 2
+
+Start: p1=3 (40), p2=1 (2), write=5
+Turn 1: write 40 → [10, 20, 20, 40, 0, 40]
+Turn 2: write 20 → [10, 20, 20, 40, 20, 40]
+Turn 3: write 20 → [10, 20, 20, 20, 20, 40]
+Turn 4: write 10 → [10, 20, 10, 20, 20, 40]
+Leftovers:          [1, 2, 10, 20, 20, 40]
+```
+
+Only `nums2` needs a leftover loop:
+
+- If `nums2` is exhausted first, remaining `nums1` values are already correctly positioned.
+- If `nums1` is exhausted first, the remaining smaller `nums2` values must fill the prefix.
+
+The algorithm does not require `m >= n`; it only requires `nums1` to have total capacity `m + n`.
+
+**Merge Strings Alternately:**
+
+```python
+def merge_alternately(word1, word2):
+    i = j = 0
+    result = []
+
+    while i < len(word1) and j < len(word2):
+        result.append(word1[i])
+        result.append(word2[j])
+        i += 1
+        j += 1
+
+    result.append(word1[i:])
+    result.append(word2[j:])
+    return ''.join(result)
+```
 
 ---
 
 ### 6. K-Sum Reduction (3Sum / 4Sum)
 
-> **Signals:** "3Sum", "4Sum", "find all triplets/quadruplets summing to target", deduplicated results
+> **Signals:** triplets or quadruplets summing to a target, unique results
 
 <PatternVizModal label="3Sum Reduction">
   <KSumReductionViz />
 </PatternVizModal>
 
-**The core idea:** Reduce k-Sum to (k−1)-Sum. 3Sum = fix one element (O(n)) × two-pointer pair search (O(n)) = O(n²). 4Sum = fix two elements (O(n²)) × two-pointer = O(n³).
+Sort the input, fix one or more anchors, then reduce the remaining task to a converging pair search:
 
-**Deduplication rules** (critical for correctness):
-1. Skip duplicate **pivot** values: `if i > 0 and nums[i] == nums[i-1]: continue`
-2. After a match, skip duplicate **left** values: `while l < r and nums[l] == nums[l-1]: l++`
-3. After a match, skip duplicate **right** values: `while l < r and nums[r] == nums[r+1]: r--`
+- 3Sum: one anchor × O(n) pair search = O(n²)
+- 4Sum: two anchors × O(n) pair search = O(n³)
+
+Deduplication is part of correctness:
+
+1. Skip duplicate anchor values.
+2. After a match, move both pointers.
+3. Skip repeated values at both pointers.
 
 ```python
 def three_sum(nums):
     nums.sort()
-    res = []
+    result = []
+
     for i in range(len(nums) - 2):
-        if i > 0 and nums[i] == nums[i - 1]:  # skip dup pivot
+        if i > 0 and nums[i] == nums[i - 1]:
             continue
-        l, r = i + 1, len(nums) - 1
-        while l < r:
-            s = nums[i] + nums[l] + nums[r]
-            if s == 0:
-                res.append([nums[i], nums[l], nums[r]])
-                while l < r and nums[l] == nums[l + 1]: l += 1  # skip dup L
-                while l < r and nums[r] == nums[r - 1]: r -= 1  # skip dup R
-                l += 1; r -= 1
-            elif s < 0:
-                l += 1
+
+        left, right = i + 1, len(nums) - 1
+
+        while left < right:
+            total = nums[i] + nums[left] + nums[right]
+
+            if total < 0:
+                left += 1
+            elif total > 0:
+                right -= 1
             else:
-                r -= 1
-    return res
+                result.append([nums[i], nums[left], nums[right]])
+                left += 1
+                right -= 1
+
+                while left < right and nums[left] == nums[left - 1]:
+                    left += 1
+                while left < right and nums[right] == nums[right + 1]:
+                    right -= 1
+
+    return result
 ```
 
-**4Sum** follows the exact same pattern with an outer loop:
+**4Sum** follows the same structure with a second fixed anchor:
 
 ```python
 def four_sum(nums, target):
     nums.sort()
-    res = []
+    result = []
+
     for i in range(len(nums) - 3):
-        if i > 0 and nums[i] == nums[i - 1]: continue
+        if i > 0 and nums[i] == nums[i - 1]:
+            continue
+
         for j in range(i + 1, len(nums) - 2):
-            if j > i + 1 and nums[j] == nums[j - 1]: continue
-            l, r = j + 1, len(nums) - 1
-            while l < r:
-                s = nums[i] + nums[j] + nums[l] + nums[r]
-                if s == target:
-                    res.append([nums[i], nums[j], nums[l], nums[r]])
-                    while l < r and nums[l] == nums[l + 1]: l += 1
-                    while l < r and nums[r] == nums[r - 1]: r -= 1
-                    l += 1; r -= 1
-                elif s < target:
-                    l += 1
+            if j > i + 1 and nums[j] == nums[j - 1]:
+                continue
+
+            left, right = j + 1, len(nums) - 1
+
+            while left < right:
+                total = (
+                    nums[i]
+                    + nums[j]
+                    + nums[left]
+                    + nums[right]
+                )
+
+                if total < target:
+                    left += 1
+                elif total > target:
+                    right -= 1
                 else:
-                    r -= 1
-    return res
+                    result.append([
+                        nums[i],
+                        nums[j],
+                        nums[left],
+                        nums[right],
+                    ])
+                    left += 1
+                    right -= 1
+
+                    while left < right and nums[left] == nums[left - 1]:
+                        left += 1
+                    while left < right and nums[right] == nums[right + 1]:
+                        right -= 1
+
+    return result
 ```
 
 ---
 
 ### 7. Running Max Walls (Trapping Rain Water)
 
-> **Signals:** "trap rain water", "amount of water trapped", elevation map / heights array
+> **Signals:** elevation map, trapped water, boundaries on both sides
 
 <PatternVizModal label="Trapping Rain Water">
   <TrappingWaterViz />
 </PatternVizModal>
 
-**The insight:** Water at position `i` is limited by the shorter of the two tallest walls on each side: `min(leftMax, rightMax) - height[i]`. Instead of precomputing both max arrays (O(n) space), use two pointers to compute them on the fly:
+Water at position `i` is limited by:
 
-- If `leftMax < rightMax`: the right wall is tall enough — water at `left` is determined purely by `leftMax`. Process left.
-- Otherwise: process right.
+```text
+min(left_max, right_max) - height[i]
+```
+
+Maintain both maxima while processing whichever side is currently safe:
 
 ```python
 def trap(height):
-    l, r = 0, len(height) - 1
+    left, right = 0, len(height) - 1
     left_max = right_max = 0
     water = 0
-    while l <= r:
+
+    while left <= right:
         if left_max <= right_max:
-            left_max = max(left_max, height[l])
-            water += left_max - height[l]
-            l += 1
+            left_max = max(left_max, height[left])
+            water += left_max - height[left]
+            left += 1
         else:
-            right_max = max(right_max, height[r])
-            water += right_max - height[r]
-            r -= 1
+            right_max = max(right_max, height[right])
+            water += right_max - height[right]
+            right -= 1
+
     return water
 ```
 
-**Why this is O(1) space:** `leftMax` and `rightMax` replace the two auxiliary arrays from the naive O(n) space solution. The two-pointer invariant guarantees the "safe side" is always processed correctly.
+The running maxima replace two auxiliary arrays, reducing extra space from O(n) to O(1).
+
+---
+
+## Two Pointers vs. Sliding Window
+
+Sliding window often uses `left` and `right`, but it maintains state for an entire contiguous range.
+
+| General two pointers | Sliding window |
+|---|---|
+| Processes values at pointer positions | Maintains state for every value in a window |
+| Eliminates candidates or builds output | Expands and shrinks a contiguous valid range |
+| Pair, symmetry, merge, or in-place signals | Longest, shortest, “at most,” substring, or subarray signals |
+
+```python
+left = 0
+
+for right in range(len(items)):
+    add(items[right])
+
+    while window_is_invalid():
+        remove(items[left])
+        left += 1
+
+    update_answer(left, right)
+```
+
+After the inner loop, `items[left:right + 1]` is valid. Treat sliding window as a related but separate pattern.
+
+---
+
+## Beyond Arrays: Fast/Slow Pointers
+
+Linked lists are not a prerequisite for array-based two pointers. After learning linked-list traversal, different pointer speeds support:
+
+- Finding the middle node
+- Detecting a cycle
+- Finding a cycle entrance
+
+```python
+slow = fast = head
+
+while fast is not None and fast.next is not None:
+    slow = slow.next
+    fast = fast.next.next
+```
+
+When `fast` reaches the end, `slow` is near the middle. In a cycle, a faster pointer eventually catches a slower one.
+
+---
+
+## Common Pitfalls
+
+### Incorrect boundaries
+
+Use `left < right` when two distinct positions are required. Use `left <= right` when a single remaining position must also be processed.
+
+### Sorting destroys original indices
+
+Retain indices before sorting when the answer requires original positions:
+
+```python
+indexed = sorted(
+    (value, index)
+    for index, value in enumerate(nums)
+)
+```
+
+### Moving without proving safety
+
+Do not memorize “small sum means move left” without identifying the ordering property that makes it true.
+
+### Overwriting unread merge values
+
+An in-place merge into `nums1` must fill from the back unless extra storage or shifting is used.
+
+### Forgetting leftovers
+
+Remaining `nums2` values must be copied. Remaining `nums1` values are already in place.
+
+### Missing empty-input handling
+
+Operations such as `k %= len(nums)` and duplicate initialization need explicit guards.
+
+### Mishandling K-sum duplicates
+
+Skip duplicate anchors and duplicate pointer values after recording a match.
+
+### Hidden string allocations
+
+Python slicing creates new strings. Use index boundaries when O(1) auxiliary space matters.
+
+### Assuming two pointers always means O(n)
+
+Sorting, anchors, and nested scans affect total complexity. State the full cost.
 
 ---
 
 ## Decision Guide: Which Pointer Strategy?
 
-| Question | Answer |
+| Question | Strategy |
 |---|---|
-| Is the array/string sorted, and am I looking for a pair? | Opposite-ends converging |
-| Does the problem have mirror symmetry (palindrome)? | Converging with comparison, skip on mismatch |
-| "In-place" + "O(1) space" + reordering/filtering? | Write pointer (slow/fast) |
-| Two separate sorted inputs to combine? | Merge two pointers (fill from back if in-place) |
-| 3+ elements summing to target, deduplicated? | K-Sum: sort + outer loop + inner converge |
-| Height/elevation, water/area, running max from both sides? | Running max walls with left/right pointers |
+| Sorted input and a pair target? | Opposite-ends converging |
+| Mirror symmetry? | Converging comparison |
+| In-place filtering or compaction? | Read/write pointers |
+| Two sorted inputs to combine? | One pointer per input; back-fill if in place |
+| Three or more values summing to a target? | Sort, fix anchors, then converge |
+| Heights and boundaries on both sides? | Running maxima with left/right pointers |
+| Best contiguous range? | Sliding window |
 
 ---
 
 ## Complexity Reference
 
-| Pattern | Time | Space | Key constraint |
+| Pattern | Time | Extra space | Key requirement |
 |---|---|---|---|
-| Opposite-ends converging | O(n) | O(1) | Must be sorted |
-| Palindrome check | O(n) | O(1) | — |
-| Reverse in-place | O(n) | O(1) | — |
-| Merge two sorted (back-fill) | O(m+n) | O(1) | nums1 must have space |
-| Write pointer | O(n) | O(1) | Must be sorted (for dups) |
-| 3Sum | O(n²) | O(1) | Must be sorted |
-| 4Sum | O(n³) | O(1) | Must be sorted |
-| Trapping Rain Water | O(n) | O(1) | — |
+| Sorted pair convergence | O(n) | O(1) | Sorted input or another monotonic rule |
+| Palindrome check | O(n) | O(1) | Mirror comparison |
+| Reverse in place | O(n) | O(1) | Mutable sequence |
+| Merge sorted, back-fill | O(m+n) | O(1) | `nums1` has capacity `m+n` |
+| Read/write filtering | O(n) | O(1) | Local keep/reject rule |
+| 3Sum | O(n²) | Sorting-dependent | Sort + one anchor |
+| 4Sum | O(n³) | Sorting-dependent | Sort + two anchors |
+| Trapping Rain Water | O(n) | O(1) | Safe-side running-max invariant |
+
+For 3Sum and 4Sum, sorting may use O(log n) or O(n) auxiliary space depending on the language and implementation. Output storage is not included.
+
+---
+
+## Recall Checklist
+
+Before coding, explain:
+
+1. What does each pointer represent?
+2. Which region is already processed?
+3. What invariant remains true?
+4. Why is the next movement safe?
+5. Does every iteration make progress?
+6. Should the loop use `<` or `<=`?
+7. Do sorting, duplicates, empty inputs, or original indices need special handling?
+
+If these answers are clear, the code is usually the easy part.

--- a/web/src/components/framework/AlgorithmPlayer.astro
+++ b/web/src/components/framework/AlgorithmPlayer.astro
@@ -26,7 +26,11 @@ const stepsJson = JSON.stringify(steps);
   <div class="teaching-content">
     <div class="anim-row">
       <p class="anim-label">Step</p>
-      <p class="anim-explanation player-explanation"></p>
+      <p
+        class="anim-explanation player-explanation"
+        aria-live="polite"
+        aria-atomic="true"
+      ></p>
     </div>
 
     <InvariantBar />

--- a/web/src/components/notes/KSumReductionViz.astro
+++ b/web/src/components/notes/KSumReductionViz.astro
@@ -53,6 +53,57 @@ const steps: TeachingStep[] = [
     ],
   },
   {
+    id: 'pivot-0-l2',
+    phase: 'compare',
+    pivot: 0,
+    left: 2,
+    right: 5,
+    triplets: [],
+    exp: 'L moves one position: nums[2]+nums[5] = −1+2 = 1 < 4. The sum is still too small, so move L again.',
+    reason: 'Show every pointer increment: a small sum only eliminates the current left value.',
+    invariant: 'The answer, if any, remains in nums[2..5].',
+    formula: '−1 + 2 = 1 < 4 → L++',
+    highlights: [
+      { target: 'cell:0', kind: 'focus' },
+      { target: 'cell:2', kind: 'compare' },
+      { target: 'cell:5', kind: 'compare' },
+    ],
+  },
+  {
+    id: 'pivot-0-l3',
+    phase: 'compare',
+    pivot: 0,
+    left: 3,
+    right: 5,
+    triplets: [],
+    exp: 'L moves again: nums[3]+nums[5] = 0+2 = 2 < 4. Keep R and advance L one more time.',
+    reason: 'Do not jump past repeated pointer moves; each comparison justifies one elimination.',
+    invariant: 'The answer, if any, remains in nums[3..5].',
+    formula: '0 + 2 = 2 < 4 → L++',
+    highlights: [
+      { target: 'cell:0', kind: 'focus' },
+      { target: 'cell:3', kind: 'compare' },
+      { target: 'cell:5', kind: 'compare' },
+    ],
+  },
+  {
+    id: 'pivot-0-l4',
+    phase: 'compare',
+    pivot: 0,
+    left: 4,
+    right: 5,
+    triplets: [],
+    exp: 'L moves again: nums[4]+nums[5] = 1+2 = 3 < 4. Advance L to 5.',
+    reason: 'The sorted order proves no smaller left value can make the sum reach 4.',
+    invariant: 'Only the final pair remains to be ruled out.',
+    formula: '1 + 2 = 3 < 4 → L++',
+    highlights: [
+      { target: 'cell:0', kind: 'focus' },
+      { target: 'cell:4', kind: 'compare' },
+      { target: 'cell:5', kind: 'compare' },
+    ],
+  },
+  {
     id: 'pivot-0-exhaust',
     phase: 'skip',
     pivot: 0,
@@ -223,15 +274,19 @@ const steps: TeachingStep[] = [
           else if (step.pivot >= 0 && i < step.pivot) cell.classList.add('visited');
         });
 
-        const setPtr = (el, idx) => {
+        const setPtr = (el, idx, offsetY = 0) => {
           if (!el || idx < 0) { if (el) el.style.visibility = 'hidden'; return; }
           el.style.visibility = 'visible';
           el.style.left = `${idx * cellWidth + cellWidth / 2}%`;
-          el.style.transform = 'translateX(-50%)';
+          el.style.transform = `translate(-50%, ${offsetY}px)`;
         };
-        setPtr(this.pivotLabel, step.pivot);
-        setPtr(this.lLabel, step.left);
-        setPtr(this.rLabel, step.right);
+        setPtr(this.pivotLabel, step.pivot, 0);
+        setPtr(this.lLabel, step.left, step.left === step.pivot ? 16 : 0);
+        setPtr(
+          this.rLabel,
+          step.right,
+          step.right === step.pivot || step.right === step.left ? 32 : 0,
+        );
 
         if (this.tripletsEl) {
           const t = step.triplets ?? [];

--- a/web/src/components/notes/MergeTwoViz.astro
+++ b/web/src/components/notes/MergeTwoViz.astro
@@ -45,8 +45,8 @@ const steps: TeachingStep[] = [
   {
     id: 'step2',
     phase: 'compare',
-    p1: 1,
-    p2: 1,
+    p1: 2,
+    p2: 0,
     pw: 3,
     arr1: [1, 2, 3, 0, 5, 6],
     exp: 'nums1[2]=3 vs nums2[1]=5: 5 > 3 → place 5 at nums1[4]. p2=0, write=3.',
@@ -62,8 +62,8 @@ const steps: TeachingStep[] = [
   {
     id: 'step3',
     phase: 'compare',
-    p1: 0,
-    p2: 1,
+    p1: 1,
+    p2: 0,
     pw: 2,
     arr1: [1, 2, 3, 3, 5, 6],
     exp: 'nums1[2]=3 vs nums2[0]=2: 3 ≥ 2 → place 3 at nums1[3]. p1=1, write=2.',
@@ -79,7 +79,7 @@ const steps: TeachingStep[] = [
   {
     id: 'step4',
     phase: 'compare',
-    p1: -1,
+    p1: 0,
     p2: 0,
     pw: 1,
     arr1: [1, 2, 2, 3, 5, 6],
@@ -96,12 +96,12 @@ const steps: TeachingStep[] = [
   {
     id: 'done',
     phase: 'found',
-    p1: -1,
+    p1: 0,
     p2: -1,
     pw: 0,
     arr1: [1, 2, 2, 3, 5, 6],
-    exp: 'p1 exhausted. Remaining nums2[0]=2 → nums1[1]=2. p2 now −1. nums1=[1,2,2,3,5,6]. Done.',
-    reason: 'When nums2 is exhausted, remaining nums1 elements are already in place. When nums1 is exhausted, remaining nums2 elements copy directly in.',
+    exp: 'nums2 is exhausted. nums1[0]=1 is already in its final position, so no copy is needed. nums1=[1,2,2,3,5,6]. Done.',
+    reason: 'When nums2 is exhausted, remaining nums1 elements are already in place. Only leftover nums2 values need to be copied.',
     invariant: 'All m+n elements merged in-place, O(m+n) time, O(1) extra space.',
     formula: 'merged: [1,2,2,3,5,6] ✓',
     highlights: [
@@ -165,14 +165,14 @@ const steps: TeachingStep[] = [
           cell.className = 'array-cell mt-a1-cell' + (i >= 3 ? ' slot' : '');
           if (i === step.pw) cell.classList.add('write-ptr');
           else if (i === step.p1) cell.classList.add('p1-ptr');
-          else if (i > step.pw) cell.classList.add('done');
+          else if (i > step.pw) cell.classList.add('finalized');
         });
 
         this.a2Cells.forEach((cell) => {
           const i = parseInt(cell.dataset.idx ?? '0', 10);
           cell.className = 'array-cell mt-a2-cell';
           if (i === step.p2) cell.classList.add('p2-ptr');
-          else if (i > step.p2) cell.classList.add('done');
+          else if (i > step.p2) cell.classList.add('consumed');
         });
       });
     }
@@ -203,6 +203,15 @@ const steps: TeachingStep[] = [
     transform: translateY(-4px);
   }
 
-  .mt-a1-cell.done .cell-val,
-  .mt-a2-cell.done .cell-val { opacity: var(--dim-hard); }
+  .mt-a1-cell.finalized .cell-val {
+    border-color: var(--status-easy);
+    background: color-mix(in srgb, var(--status-easy) 10%, transparent);
+    color: var(--status-easy);
+  }
+
+  .mt-a2-cell.consumed .cell-val {
+    opacity: var(--dim-hard);
+    border-style: dashed;
+    text-decoration: line-through;
+  }
 </style>

--- a/web/src/components/notes/MergeTwoViz.astro
+++ b/web/src/components/notes/MergeTwoViz.astro
@@ -100,10 +100,10 @@ const steps: TeachingStep[] = [
     p2: -1,
     pw: 0,
     arr1: [1, 2, 2, 3, 5, 6],
-    exp: 'nums2 is exhausted. nums1[0]=1 is already in its final position, so no copy is needed. nums1=[1,2,2,3,5,6]. Done.',
-    reason: 'When nums2 is exhausted, remaining nums1 elements are already in place. Only leftover nums2 values need to be copied.',
+    exp: 'nums1[0]=1 vs nums2[0]=2: 2 > 1 → place 2 at nums1[1]. p2=-1, write=0. nums2 is now exhausted, and nums1[0]=1 is already in its final position. Done.',
+    reason: 'The final nums2 value must be copied before nums2 is exhausted. After that, any remaining nums1 values are already correctly positioned.',
     invariant: 'All m+n elements merged in-place, O(m+n) time, O(1) extra space.',
-    formula: 'merged: [1,2,2,3,5,6] ✓',
+    formula: '2 > 1 → nums1[1]=2; p2--; write--; merged: [1,2,2,3,5,6] ✓',
     highlights: [
       { target: 'a1:0', kind: 'confirmed' },
       { target: 'a1:1', kind: 'confirmed' },

--- a/web/src/components/notes/RemoveDupsViz.astro
+++ b/web/src/components/notes/RemoveDupsViz.astro
@@ -157,6 +157,7 @@ const steps: TeachingStep[] = [
           const i = parseInt(cell.dataset.idx ?? '0', 10);
           cell.className = 'array-cell rd-cell';
           if (step.phase === 'found' && i <= step.slow) cell.classList.add('found');
+          else if (step.phase === 'found') cell.classList.add('ignored-tail');
           else if (i === step.slow) cell.classList.add('slow-ptr');
           else if (i === step.fast) cell.classList.add('fast-ptr');
           else if (i > step.slow && i < step.fast) cell.classList.add('scanned');
@@ -216,6 +217,12 @@ const steps: TeachingStep[] = [
     color: var(--status-medium);
     background: rgba(255, 192, 30, 0.08);
     transform: translateY(-4px);
+  }
+
+  .rd-cell.ignored-tail .cell-val {
+    opacity: var(--dim-soft);
+    border-style: dashed;
+    text-decoration: line-through;
   }
 
   .rd-cell.found .cell-val {

--- a/web/src/components/notes/ReverseRotateViz.astro
+++ b/web/src/components/notes/ReverseRotateViz.astro
@@ -98,14 +98,24 @@ const steps: TeachingStep[] = [
       this.vals = Array.from(this.querySelectorAll('.rr-val'));
       this.lLabel = this.querySelector('.rr-l-label');
       this.rLabel = this.querySelector('.rr-r-label');
+      this.previousArr = ['h', 'e', 'l', 'l', 'o'];
 
       this.addEventListener('step-change', (e) => {
         const step = e.detail.step;
         const count = this.chars.length;
         const cellWidth = 100 / count;
 
+        const changedIndexes = new Set(
+          (step.arr ?? [])
+            .map((value, index) => (
+              value !== this.previousArr[index] ? index : -1
+            ))
+            .filter((index) => index >= 0),
+        );
+
         if (step.arr && this.vals.length === step.arr.length) {
           step.arr.forEach((ch, i) => { this.vals[i].textContent = ch; });
+          this.previousArr = [...step.arr];
         }
 
         this.chars.forEach((ch) => {
@@ -114,6 +124,7 @@ const steps: TeachingStep[] = [
           if (step.phase === 'found') ch.classList.add('found');
           else if (i === step.left || i === step.right) ch.classList.add('active');
           else if (i < step.left || i > step.right) ch.classList.add('done');
+          if (changedIndexes.has(i)) ch.classList.add('swapped');
         });
 
         const setPtr = (el, idx) => {
@@ -152,6 +163,16 @@ const steps: TeachingStep[] = [
   }
 
   .rr-char.done .cell-val { opacity: 0.4; }
+
+  .rr-char.swapped .cell-val {
+    animation: rr-swap-pop 0.45s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+
+  @keyframes rr-swap-pop {
+    0% { transform: translateY(0) scale(1); }
+    45% { transform: translateY(-10px) scale(1.12); }
+    100% { transform: translateY(0) scale(1); }
+  }
 
   .rr-char.active { transform: translateY(-4px); }
   .rr-char.active .cell-val {

--- a/web/src/components/notes/TrappingWaterViz.astro
+++ b/web/src/components/notes/TrappingWaterViz.astro
@@ -156,7 +156,7 @@ const steps: TeachingStep[] = [
         {heights.map((h, i) => (
           <div class="tw-col" data-idx={i} data-teach-target={`cell:${i}`}>
             <div class="tw-bar-stack">
-              <div class="tw-water" aria-hidden="true"></div>
+              <div class="tw-water-overlay" aria-hidden="true"></div>
               <div class="tw-bar" style={`height: ${h * 18 + 4}px`}>{h}</div>
             </div>
             <span class="cell-idx">{i}</span>
@@ -186,7 +186,7 @@ const steps: TeachingStep[] = [
           if (i === step.left || i === step.right) col.classList.add('active');
           else if (i < step.left || i > step.right) col.classList.add('visited');
 
-          const water = col.querySelector('.tw-water');
+          const water = col.querySelector('.tw-water-overlay');
           const units = step.phase === 'found' ? this.waterUnits[i] : 0;
           if (water) {
             water.style.height = `${units * 18}px`;
@@ -250,7 +250,7 @@ const steps: TeachingStep[] = [
     min-height: 4px;
   }
 
-  .tw-water {
+  .tw-water-overlay {
     position: absolute;
     bottom: 0;
     width: 100%;
@@ -266,7 +266,7 @@ const steps: TeachingStep[] = [
     transition: height 0.3s ease, opacity 0.2s ease;
   }
 
-  .tw-water.visible { opacity: 1; }
+  .tw-water-overlay.visible { opacity: 1; }
 
   .tw-col .cell-idx {
     font-size: var(--fs-micro);

--- a/web/src/components/notes/TrappingWaterViz.astro
+++ b/web/src/components/notes/TrappingWaterViz.astro
@@ -154,8 +154,11 @@ const steps: TeachingStep[] = [
       <p class="anim-label">Heights</p>
       <div class="tw-bar-chart">
         {heights.map((h, i) => (
-          <div class="tw-col" data-idx={i} data-height={h} data-teach-target={`cell:${i}`}>
-            <div class="tw-bar" style={`height: ${h * 18 + 4}px`}>{h}</div>
+          <div class="tw-col" data-idx={i} data-teach-target={`cell:${i}`}>
+            <div class="tw-bar-stack">
+              <div class="tw-water" aria-hidden="true"></div>
+              <div class="tw-bar" style={`height: ${h * 18 + 4}px`}>{h}</div>
+            </div>
             <span class="cell-idx">{i}</span>
           </div>
         ))}
@@ -172,6 +175,7 @@ const steps: TeachingStep[] = [
       this.rmaxEl = this.querySelector('.tw-rmax');
       this.waterEl = this.querySelector('.tw-water');
       this.waterBox = this.querySelector('[data-teach-target="water-box"]');
+      this.waterUnits = [0, 0, 1, 0, 1, 2, 1, 0, 0, 1, 0, 0];
 
       this.addEventListener('step-change', (e) => {
         const step = e.detail.step;
@@ -181,6 +185,13 @@ const steps: TeachingStep[] = [
           col.className = 'tw-col';
           if (i === step.left || i === step.right) col.classList.add('active');
           else if (i < step.left || i > step.right) col.classList.add('visited');
+
+          const water = col.querySelector('.tw-water');
+          const units = step.phase === 'found' ? this.waterUnits[i] : 0;
+          if (water) {
+            water.style.height = `${units * 18}px`;
+            water.classList.toggle('visible', units > 0);
+          }
         });
 
         if (this.lmaxEl) this.lmaxEl.textContent = String(step.leftMax ?? 0);
@@ -215,7 +226,15 @@ const steps: TeachingStep[] = [
     transition: opacity 0.2s;
   }
 
+  .tw-bar-stack {
+    position: relative;
+    width: 22px;
+    height: 58px;
+  }
+
   .tw-bar {
+    position: absolute;
+    bottom: 0;
     width: 22px;
     background: var(--accent-dim);
     border: 1px solid var(--accent);
@@ -230,6 +249,24 @@ const steps: TeachingStep[] = [
     transition: background 0.2s, border-color 0.2s;
     min-height: 4px;
   }
+
+  .tw-water {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    background: repeating-linear-gradient(
+      135deg,
+      rgb(var(--accent-rgb) / 42%) 0 4px,
+      rgb(var(--accent-rgb) / 22%) 4px 8px
+    );
+    border: 1px solid rgb(var(--accent-rgb) / 70%);
+    border-bottom: 0;
+    border-radius: 3px 3px 0 0;
+    opacity: 0;
+    transition: height 0.3s ease, opacity 0.2s ease;
+  }
+
+  .tw-water.visible { opacity: 1; }
 
   .tw-col .cell-idx {
     font-size: var(--fs-micro);

--- a/web/src/components/notes/TrappingWaterViz.astro
+++ b/web/src/components/notes/TrappingWaterViz.astro
@@ -156,7 +156,11 @@ const steps: TeachingStep[] = [
         {heights.map((h, i) => (
           <div class="tw-col" data-idx={i} data-teach-target={`cell:${i}`}>
             <div class="tw-bar-stack">
-              <div class="tw-water-overlay" aria-hidden="true"></div>
+              <div
+                class="tw-water-overlay"
+                style={`bottom: ${h * 18 + 4}px`}
+                aria-hidden="true"
+              ></div>
               <div class="tw-bar" style={`height: ${h * 18 + 4}px`}>{h}</div>
             </div>
             <span class="cell-idx">{i}</span>


### PR DESCRIPTION
## TL;DR

Polishes the Two Pointers learning note and its interactive visualizations to make invariants, pointer movement, and in-place state changes easier to follow.

## Notes

- Reorganizes the Two Pointers guide around a shared mental model and pointer-motion families.
- Expands merge-from-back and read/write explanations, with decision guidance, pitfalls, complexity notes, and recall checks.
- Clarifies the boundary with sliding window and introduces fast/slow pointers as a later extension.

## Visualizations

- Adds visible trapped-water overlays.
- Splits K-Sum pointer movement into smaller instructional steps and offsets colliding labels.
- Distinguishes finalized merge output from consumed input values.
- Adds swap feedback for reverse-string and a clear valid-prefix/ignored-tail result for duplicate removal.
- Announces step explanations through a polite live region.

## Testing

- `npm run build --silent`
- `git diff --check`

🌸 Generated with [AdaL](https://github.com/adal-cli/)
