### PR TITLE
feat: add SQL practice and guided DSA notes

### DIFF
--- a/notes/sliding_window.mdx
+++ b/notes/sliding_window.mdx
@@ -1,0 +1,515 @@
+---
+title: Sliding Window
+description: A problem-first guide to fixed and variable sliding windows, their state invariants, and the practice problems that build each one.
+category: Patterns
+order: 4
+status: stable
+tags:
+  - dsa
+  - sliding-window
+  - arrays
+  - strings
+---
+
+import PatternVizModal from '../web/src/components/notes/PatternVizModal.astro';
+import BuySellStockAnimation from '../web/src/components/BuySellStockAnimation.astro';
+import LongestSubstringAnimation from '../web/src/components/LongestSubstringAnimation.astro';
+import CharacterReplacementAnimation from '../web/src/components/CharacterReplacementAnimation.astro';
+import PermutationInStringAnimation from '../web/src/components/PermutationInStringAnimation.astro';
+import SlidingWindowMaximumAnimation from '../web/src/components/SlidingWindowMaximumAnimation.astro';
+
+# Sliding Window
+
+A sliding window maintains a **contiguous** range while it moves through an array or string. Rather than recomputing every possible range, it updates a small amount of state as one value enters from the right and, when necessary, one value leaves from the left.
+
+The important idea is not two variables named `left` and `right`. It is this contract:
+
+> The state describes exactly the current window, and moving `left` restores the rule that makes the window useful.
+
+This note is a study path, not a catalogue. Learn the window's rule, solve its anchor problem, then change one constraint in the next problem.
+
+---
+
+## How To Use This Note
+
+For each family:
+
+1. Read the recognition signal before seeing the code.
+2. Say what `left`, `right`, and the window state represent.
+3. Decide whether the window has fixed width or is allowed to grow.
+4. State the condition that makes a window valid.
+5. Predict when and why `left` must move.
+6. Solve the anchor problem, then make the single change in its follow-up.
+
+If you get stuck, write the window invariant in one sentence. It usually tells you both what to store and when to shrink.
+
+---
+
+## Pattern Map
+
+Use the phrasing of the question to pick the right window family. The state is what makes each family different.
+
+| If the problem says... | Reach for... | State to maintain | Start with |
+|---|---|---|---|
+| Buy before sell; maximize a later-minus-earlier value | Forward-pair scan | Best eligible earlier value | [Best Time to Buy and Sell Stock](../../algorithms/121-best-time-to-buy-and-sell-stock) |
+| Check every substring of exactly length `k` | Fixed-size window | Counts, sum, or another rolling summary | [Permutation in String](../../algorithms/567-permutation-in-string) |
+| Longest or shortest valid substring/subarray | Variable-size window | State that says whether the current range is valid | [Longest Substring Without Repeating Characters](../../algorithms/3-longest-substring-without-repeating-characters) |
+| Longest range after at most `k` changes, deletions, or replacements | Budgeted variable window | Cost needed to repair the current range | [Longest Repeating Character Replacement](../../algorithms/424-longest-repeating-character-replacement) |
+| Maximum or minimum for every fixed-size window | Window plus candidate structure | A monotonic deque of undominated candidates | [Sliding Window Maximum](../../algorithms/239-sliding-window-maximum) |
+
+### Suggested Study Route
+
+This sequence starts with a single forward scan, then adds exactly one kind of window state at a time.
+
+| Step | Problem | New idea to own |
+|---|---|---|
+| 1 | [Best Time to Buy and Sell Stock](../../algorithms/121-best-time-to-buy-and-sell-stock) | Keep the best feasible left boundary while scanning right |
+| 2 | [Permutation in String](../../algorithms/567-permutation-in-string) | Slide a fixed-width frequency map |
+| 3 | [Longest Substring Without Repeating Characters](../../algorithms/3-longest-substring-without-repeating-characters) | Grow, then shrink until the invariant is restored |
+| 4 | [Longest Repeating Character Replacement](../../algorithms/424-longest-repeating-character-replacement) | Express validity as a repair budget |
+| 5 | [Sliding Window Maximum](../../algorithms/239-sliding-window-maximum) | Keep only candidates that can still win |
+
+The last two problems are currently filed in the Stack section of the practice bank, but their core technique belongs in this sliding-window progression.
+
+---
+
+## The Window Contract
+
+For a window `items[left:right + 1]`:
+
+```text
+left    first item still inside the current window
+right   most recently added item
+state   summary of exactly the items from left through right
+answer  best valid window seen so far, when the task asks for one
+```
+
+Most variable-window solutions follow this rhythm:
+
+```python
+left = 0
+state = empty_state()
+
+for right, value in enumerate(items):
+    add(state, value)
+
+    while window_is_invalid(state, left, right):
+        remove(state, items[left])
+        left += 1
+
+    update_answer(left, right)
+```
+
+The order matters:
+
+1. Add the new right value to state.
+2. Shrink until the window is valid again.
+3. Only then use the window as a candidate answer.
+
+For a fixed-size window, the rule is different: shrink whenever the width grows beyond the required size, then inspect only windows with exactly that size.
+
+---
+
+## 1. Forward-Pair Scan: Best Time To Buy And Sell Stock
+
+### Recognize It
+
+This is a useful entry point because it shares the forward-moving boundaries of sliding window, but it does not maintain a conventional range property. The question asks:
+
+- Choose an earlier buy and a later sell.
+- Maximize `sell - buy`.
+- Use one transaction only.
+
+The useful state is the best eligible **past** partner for the current day: the lowest price seen so far.
+
+<PatternVizModal label="Best Time to Buy and Sell Stock">
+  <BuySellStockAnimation />
+</PatternVizModal>
+
+### Anchor Problem: Best Time To Buy And Sell Stock
+
+```python
+def max_profit(prices: list[int]) -> int:
+    lowest_price = float("inf")
+    best_profit = 0
+
+    for price in prices:
+        lowest_price = min(lowest_price, price)
+        best_profit = max(best_profit, price - lowest_price)
+
+    return best_profit
+```
+
+### The Invariant
+
+After processing each price:
+
+```text
+lowest_price is the smallest price seen on this day or any earlier day.
+best_profit is the best legal buy-then-sell profit seen so far.
+```
+
+Every day is considered as a possible sell day exactly once. The only buy price worth pairing with it is the cheapest earlier price. Any more expensive earlier buy produces less profit and can be discarded forever.
+
+### Why This Is Related, But Not A Standard Window
+
+The code can be written with two pointers, but the key idea is a running minimum, not "make a range valid." Treat it as preparation for the broader pattern: compress all useful information from the left side into a small state instead of rescanning it.
+
+### Check Yourself
+
+- Why must the minimum price come from the current day or an earlier day?
+- Why does a lower buy price make every earlier, higher buy price irrelevant?
+- Why must the answer begin at `0`, not negative infinity?
+
+---
+
+## 2. Fixed-Size Windows: Permutation In String
+
+### Recognize It
+
+Use a fixed-size window when every candidate range must have the same width:
+
+- "contains a permutation/anagram"
+- "every substring of length `k`"
+- "average, sum, or count in every block of `k` values"
+
+The window does not choose its own width. It advances exactly one step at a time after it reaches the required size.
+
+### Anchor Problem: Permutation In String
+
+[Permutation in String](../../algorithms/567-permutation-in-string) asks whether `s2` contains a contiguous permutation of `s1`. A permutation has the same character frequencies, so only windows of length `len(s1)` can qualify.
+
+<PatternVizModal label="Fixed-Size Frequency Window">
+  <PermutationInStringAnimation />
+</PatternVizModal>
+
+```python
+def check_inclusion(pattern: str, text: str) -> bool:
+    if len(pattern) > len(text):
+        return False
+
+    needed = {}
+    window = {}
+
+    for char in pattern:
+        needed[char] = needed.get(char, 0) + 1
+
+    left = 0
+    for right, char in enumerate(text):
+        window[char] = window.get(char, 0) + 1
+
+        if right - left + 1 > len(pattern):
+            leaving = text[left]
+            window[leaving] -= 1
+            if window[leaving] == 0:
+                del window[leaving]
+            left += 1
+
+        if right - left + 1 == len(pattern) and window == needed:
+            return True
+
+    return False
+```
+
+### The Invariant
+
+After the optional shrink step:
+
+```text
+text[left:right + 1] has width at most len(pattern).
+window stores exactly that range's character frequencies.
+When the width equals len(pattern), it is one complete permutation candidate.
+```
+
+Deleting a key whose count becomes zero matters. `{ "a": 1 }` and `{ "a": 1, "b": 0 }` describe the same characters but are not equal dictionaries.
+
+### Why This Is O(n)
+
+Each slide performs constant rolling work: add one character and, once full, remove one character. It never recounts an entire substring. With the lowercase-English alphabet in this problem, map comparison is bounded by 26 keys, so it is constant per window.
+
+### Change One Rule
+
+If the question asks for **all** matching positions rather than a boolean, append `left` when the maps match instead of returning. The fixed-width invariant stays unchanged.
+
+### Check Yourself
+
+- Why can no window shorter or longer than `len(pattern)` be a permutation?
+- Why must the leaving character be removed before `left` moves?
+- What changes if the input alphabet is not bounded to a small constant?
+
+---
+
+## 3. Variable Windows: Longest Unique Substring
+
+### Recognize It
+
+Use a variable-size window for prompts such as:
+
+- "longest substring/subarray such that..."
+- "at most `k` distinct values"
+- "no duplicates"
+- "shortest range that contains..."
+
+The right edge tries to grow the answer. The left edge moves only when the new value breaks the validity rule.
+
+### Anchor Problem: Longest Substring Without Repeating Characters
+
+For [Longest Substring Without Repeating Characters](../../algorithms/3-longest-substring-without-repeating-characters), the rule is simple: every character in the window must be unique.
+
+<PatternVizModal label="Variable-Size Unique Window">
+  <LongestSubstringAnimation />
+</PatternVizModal>
+
+```python
+def length_of_longest_substring(s: str) -> int:
+    seen = set()
+    left = 0
+    best = 0
+
+    for right, char in enumerate(s):
+        while char in seen:
+            seen.remove(s[left])
+            left += 1
+
+        seen.add(char)
+        best = max(best, right - left + 1)
+
+    return best
+```
+
+### The Invariant
+
+At the end of every iteration:
+
+```text
+s[left:right + 1] contains no duplicate characters.
+seen contains exactly the characters in that window.
+best is the length of the longest valid window seen so far.
+```
+
+The new `char` is not inserted until old characters have been removed far enough to make room for it. This keeps the set and the window in agreement.
+
+### Why The Inner Loop Is Still Linear
+
+The nested `while` does not make the algorithm O(n^2). `right` visits each character once. `left` only moves forward, and it removes each character at most once. Across the whole scan, there are at most `n` additions and `n` removals.
+
+### Do Not Reset The Window
+
+For `"abba"`, a duplicate does not mean discard everything and start over. When the second `b` arrives, shrink from the left just enough to remove the older `b`; the valid window is then `"ba"`. Resetting loses valid progress and breaks the invariant.
+
+### Check Yourself
+
+- Why must the invalidity repair use `while`, not one `if`?
+- Why update `best` only after the duplicate is gone?
+- What state would let you jump `left` directly to the last seen position?
+
+---
+
+## 4. Budgeted Windows: Character Replacement
+
+### Recognize It
+
+This family allows a limited number of repairs inside the window:
+
+- at most `k` replacements
+- at most `k` deletions or flips
+- longest range that can become valid after limited edits
+
+The central question becomes: **how many changes would make this window acceptable?**
+
+### Anchor Problem: Longest Repeating Character Replacement
+
+In [Longest Repeating Character Replacement](../../algorithms/424-longest-repeating-character-replacement), the cheapest way to make a window uniform is to preserve its most frequent character and replace every other character.
+
+```text
+replacements needed = window length - highest frequency in the window
+```
+
+<PatternVizModal label="Budgeted Character Window">
+  <CharacterReplacementAnimation />
+</PatternVizModal>
+
+```python
+def character_replacement(s: str, k: int) -> int:
+    counts = {}
+    left = 0
+    best = 0
+
+    for right, char in enumerate(s):
+        counts[char] = counts.get(char, 0) + 1
+
+        while (right - left + 1) - max(counts.values()) > k:
+            leaving = s[left]
+            counts[leaving] -= 1
+            left += 1
+
+        best = max(best, right - left + 1)
+
+    return best
+```
+
+### The Invariant
+
+After shrinking:
+
+```text
+window length - max frequency in counts <= k.
+The current window can be made entirely one character using at most k replacements.
+best is the largest such window seen so far.
+```
+
+The code recomputes the maximum frequency from the map so the invariant directly describes the actual current window. Because this problem has only 26 uppercase letters, that is still O(n). A common optimization keeps a non-decreasing historical maximum frequency, but learn the direct proof before using that shortcut.
+
+### Why Shrink Instead Of Restarting
+
+When a window costs too many replacements, removing its leftmost value is the only way to reduce its width while preserving the newest right value. Keeping the right edge matters because it may belong to the next longest valid window.
+
+### Check Yourself
+
+- Why is the number of replacements `length - most_frequent_count`?
+- Why is a window with cost exactly `k` still valid?
+- What goes wrong if you decrement the count after incrementing `left`?
+
+---
+
+## 5. Fixed-Size Extremes: Sliding Window Maximum
+
+### Recognize It
+
+The normal fixed-size recipe is not enough when every window asks for an extreme value:
+
+- maximum or minimum of every window of width `k`
+- repeated max/min queries as the window slides
+- recomputing each window's extreme would cost O(n * k)
+
+[Sliding Window Maximum](../../algorithms/239-sliding-window-maximum) adds a monotonic deque that stores only candidates that could still become a future maximum.
+
+<PatternVizModal label="Monotonic Deque Window">
+  <SlidingWindowMaximumAnimation />
+</PatternVizModal>
+
+### The Candidate Rule
+
+Store indices in a deque so the values decrease from front to back:
+
+```text
+front                                            back
+largest candidate -> smaller backup candidates -> smallest candidate
+```
+
+When a new value arrives, remove smaller or equal values from the back. The new value is at least as good and is newer, so it will remain in every future window that the smaller value could occupy.
+
+```python
+from collections import deque
+
+
+def max_sliding_window(nums: list[int], k: int) -> list[int]:
+    candidates = deque()
+    result = []
+
+    for right, value in enumerate(nums):
+        window_start = right - k + 1
+
+        while candidates and candidates[0] < window_start:
+            candidates.popleft()
+
+        while candidates and nums[candidates[-1]] <= value:
+            candidates.pop()
+
+        candidates.append(right)
+
+        if right >= k - 1:
+            result.append(nums[candidates[0]])
+
+    return result
+```
+
+### The Invariant
+
+After processing index `right`:
+
+```text
+Every deque index is inside the current window.
+Deque values decrease from front to back.
+The front index therefore points to the current window maximum.
+```
+
+Each index enters the deque once and leaves it once, either because it expires at the front or a newer value dominates it at the back. That makes the total time O(n), not O(n * k).
+
+### A Useful Progression
+
+| Approach | Time | What it teaches |
+|---|---|---|
+| Recompute `max(window)` | O(n * k) | The baseline cost to beat |
+| Heap with lazy eviction | O(n log n) | Track indices so stale values can be rejected |
+| Monotonic deque | O(n) | Discard permanently dominated candidates |
+
+The saved implementation for this problem currently uses the heap approach. The deque above is the next optimization to master; its animation already shows the candidate invariant.
+
+### Check Yourself
+
+- Why store indices instead of values in the deque?
+- Why can a newer value remove a smaller value from the back permanently?
+- Why must expired indices be removed from the front before reading the maximum?
+
+---
+
+## Sliding Window Vs. General Two Pointers
+
+Both techniques use boundaries that move forward, but they answer different questions.
+
+| Sliding window | General two pointers |
+|---|---|
+| Maintains state for every value in one contiguous range | Eliminates candidates, compares endpoints, merges inputs, or builds output |
+| `right` usually expands; `left` restores a window rule or fixed width | Movement follows a sorted-order proof, greedy bound, mirror rule, or output invariant |
+| Signals: longest, shortest, at most, substring, subarray, every block of `k` | Signals: pair, symmetry, sorted endpoints, two inputs, in-place filtering |
+| State might be counts, sum, a set, or a deque | State might be none beyond the pointers, or a small problem-specific summary |
+
+If the task asks about a **contiguous range** and a condition that can be updated as endpoints move, investigate sliding window first.
+
+---
+
+## Debugging Checklist
+
+When a window solution is wrong, inspect these contracts before changing conditions at random:
+
+| Symptom | Question to ask |
+|---|---|
+| The map or set disagrees with the displayed window | Did I remove `items[left]` from state before advancing `left`? |
+| The window grows past a fixed width | Did I shrink whenever `right - left + 1 > k`? |
+| An invalid window updates the answer | Am I updating after validity is restored? |
+| A duplicate still remains | Does this problem require a `while` loop rather than a single `if`? |
+| Frequency maps never match | Did I delete a key after its count reached zero? |
+| Character Replacement is off by one | Is validity `window length - max frequency <= k`? |
+| Sliding Window Maximum reports an expired value | Are deque entries indices, and do I evict entries before the current window start? |
+| A stock answer buys after it sells | Does the tracked minimum come only from current or earlier days? |
+
+---
+
+## Complexity Reference
+
+| Family | Time | Extra space | Main reason |
+|---|---|---|---|
+| Best Time to Buy and Sell Stock | O(n) | O(1) | Keep only the best prior buy price |
+| Fixed-size frequency window | O(n) for a bounded alphabet | O(alphabet) | One value enters and leaves per slide |
+| Longest unique substring | O(n) | O(min(n, alphabet)) | Each character enters and leaves the set at most once |
+| Budgeted character window | O(n) for a bounded alphabet | O(alphabet) | Window state changes incrementally; alphabet has 26 letters |
+| Sliding Window Maximum with heap | O(n log n) | O(n) | Heap operations and lazy stale entries |
+| Sliding Window Maximum with deque | O(n) | O(k) | Each index enters and leaves the deque once |
+
+For arbitrary, unbounded alphabets, comparing whole frequency maps can cost O(alphabet) per comparison. Use a match counter when strict O(n) behavior is required.
+
+---
+
+## Final Recall
+
+Before coding a sliding-window problem, say these answers out loud:
+
+1. Is the window fixed-size or variable-size?
+2. What does the state represent exactly?
+3. What makes a window valid, and how do I repair invalidity?
+4. When is it safe to update the answer?
+5. Does each item enter and leave the state at most once?
+6. Do I need all window values, or only undominated candidates?
+
+If those answers are clear, the implementation is usually a short loop. If not, solve the earlier problem in the same family before moving on.

--- a/notes/two_pointers.mdx
+++ b/notes/two_pointers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Two Pointers
-description: Core patterns, decision frameworks, and animations for the Two Pointers topic in NeetCode 250.
+description: A problem-first guide to two-pointer patterns, their invariants, and the practice problems that build each one.
 category: Patterns
 order: 3
 status: stable
@@ -21,232 +21,111 @@ import TrappingWaterViz from '../web/src/components/notes/TrappingWaterViz.astro
 
 # Two Pointers
 
-Two pointers is a family of techniques in which two positions move through one or more sequences without repeatedly revisiting the same work. The pointers may converge, move in the same direction, or belong to separate inputs.
+Two pointers is not one algorithm. It is a way to organize a scan so that each pointer movement discards work, confirms work, or writes a final result without starting over.
 
-The important idea is not merely that there are two variables. Every movement must be justified by an invariant or a safe elimination rule.
+The variable names are the easy part. The skill is being able to finish this sentence before you code:
 
----
+> I can move this pointer because every candidate I skip is no longer capable of improving or changing the answer.
 
-## Table of Contents
-
-- [Core Mental Model](#core-mental-model)
-- [Pointer-Motion Families](#pointer-motion-families)
-- [Pattern Recognition Guide](#pattern-recognition-guide)
-- [Core Patterns](#core-patterns)
-  - [1. Opposite-Ends Converging](#1-opposite-ends-converging-sorted-array)
-  - [2. Palindrome Check](#2-palindrome-check--skip)
-  - [3. Reverse / Rotate In-Place](#3-reverse--rotate-in-place)
-  - [4. Read/Write Pointers](#4-readwrite-pointers-in-place-filtering)
-  - [5. Merge Two Sorted Sequences](#5-merge-two-sorted-sequences)
-  - [6. K-Sum Reduction](#6-k-sum-reduction-3sum--4sum)
-  - [7. Running Max Walls](#7-running-max-walls-trapping-rain-water)
-- [Two Pointers vs. Sliding Window](#two-pointers-vs-sliding-window)
-- [Beyond Arrays: Fast/Slow Pointers](#beyond-arrays-fastslow-pointers)
-- [Common Pitfalls](#common-pitfalls)
-- [Decision Guide](#decision-guide-which-pointer-strategy)
-- [Complexity Reference](#complexity-reference)
-- [Recall Checklist](#recall-checklist)
+This note is a study path, not a catalogue. Work one family at a time: understand its movement rule, solve the anchor problem, then change one constraint in the next problem.
 
 ---
 
-## Core Mental Model
+## How To Use This Note
 
-Before writing code, answer three questions:
+For each family:
 
-1. **What does each pointer represent?**
-2. **What region has already been processed?**
-3. **Why is the next pointer movement safe?**
+1. Read the recognition signal before seeing the code.
+2. Name what each pointer represents and what is already settled.
+3. Predict the next move on the example.
+4. Read the movement proof. Do not memorize the move without its proof.
+5. Solve the anchor problem from scratch.
+6. Attempt the follow-up problem and identify exactly what changed.
 
-For sorted pair search, order makes it safe to eliminate one endpoint. For read/write filtering, the output prefix is already complete. For an in-place merge, the suffix after the write pointer is already in its final position.
-
-Two pointers often turns an O(n²) pair search into O(n), but not always:
-
-- Sorting first can make the total O(n log n).
-- 3Sum uses an outer loop plus a linear scan, so it remains O(n²).
-- The real benefit is avoiding unnecessary repeated work.
-
-If pointers move only forward or inward and never reset, they usually make at most O(n) movements in total.
+If you get stuck, return to the invariant rather than reaching for a remembered template.
 
 ---
 
-## Pointer-Motion Families
+## Pattern Map
 
-### A. Converging pointers
+Use the problem statement to choose a family. The same pointer shape can have different movement proofs, so the last column matters as much as the first.
 
-Start at opposite ends and move inward.
+| If the problem says... | Reach for... | Why a move is safe | Start with |
+|---|---|---|---|
+| Compare values at mirrored positions or reverse in place | Mirror and swap | The outer pair is checked or swapped forever | [Reverse String](../../algorithms/344-reverse-string) |
+| Find a target pair in sorted input | Sorted-pair elimination | Sorted order rules out an endpoint | [Two Sum II](../../algorithms/167-two-sum-ii-input-array-is-sorted) |
+| Maximize a score formed by two endpoints | Limiting-endpoint greedy | The shorter endpoint caps every pair that keeps it | [Container With Most Water](../../algorithms/11-container-with-most-water) |
+| Remove or compact values in place | Read/write compaction | The written prefix is already the final output | [Remove Duplicates from Sorted Array](../../algorithms/26-remove-duplicates-from-sorted-array) |
+| Consume two sequences together | Two-input traversal | Everything before the read pointers is handled | [Merge Strings Alternately](../../algorithms/1768-merge-strings-alternately) |
+| Find unique triples or quadruples | Anchor plus pair search | Sorting enables pair elimination after fixing anchors | [3Sum](../../algorithms/15-3sum) |
+| A value depends on boundaries from both sides | Safe-side state | The smaller known boundary fixes that side's answer | [Trapping Rain Water](../../algorithms/42-trapping-rain-water) |
 
-```python
-left, right = 0, len(items) - 1
+### Suggested Study Route
 
-while left < right:
-    if should_move_left:
-        left += 1
-    else:
-        right -= 1
-```
+This order builds one idea at a time. Do not skip to 3Sum or Trapping Rain Water until the movement rule in the earlier problem feels natural.
 
-Typical uses: sorted pair search, palindrome checks, reversal, and maximum-area problems.
-
-**Invariant:** everything outside `[left, right]` has been processed or safely eliminated.
-
-### B. Read/write pointers
-
-Both move forward, but they have different jobs.
-
-```python
-write = 0
-
-for read in range(len(items)):
-    if should_keep(items[read]):
-        items[write] = items[read]
-        write += 1
-```
-
-Typical uses: remove elements, remove duplicates, move selected values, and compact an array in place.
-
-**Invariant:** `items[:write]` is the completed output built from the input examined so far.
-
-### C. One pointer per input
-
-Each pointer tracks one sequence. A separate output pointer may record where the next result belongs.
-
-```python
-i = j = 0
-
-while i < len(a) and j < len(b):
-    if a[i] <= b[j]:
-        take(a[i])
-        i += 1
-    else:
-        take(b[j])
-        j += 1
-```
-
-Typical uses: merging or intersecting sorted sequences.
-
-**Invariant:** everything before `i` and `j` has already been handled.
-
-### D. Fixed anchor plus converging pointers
-
-Fix one or more values, then use converging pointers on the remaining sorted suffix.
-
-Typical uses: 3Sum, 4Sum, and general K-sum reduction.
+| Step | Problem | New idea to own |
+|---|---|---|
+| 1 | [Reverse String](../../algorithms/344-reverse-string) | Move both ends after settling a mirrored pair |
+| 2 | [Valid Palindrome](../../algorithms/125-valid-palindrome) | Skip irrelevant input before comparing |
+| 3 | [Valid Palindrome II](../../algorithms/680-valid-palindrome-ii) | Branch exactly once at the first mismatch |
+| 4 | [Two Sum II](../../algorithms/167-two-sum-ii-input-array-is-sorted) | Use sorted order to eliminate an endpoint |
+| 5 | [Container With Most Water](../../algorithms/11-container-with-most-water) | Prove a greedy endpoint move |
+| 6 | [Remove Duplicates from Sorted Array](../../algorithms/26-remove-duplicates-from-sorted-array) | Build an answer in the input prefix |
+| 7 | [Merge Strings Alternately](../../algorithms/1768-merge-strings-alternately) | Coordinate one pointer per input |
+| 8 | [Merge Sorted Array](../../algorithms/88-merge-sorted-array) | Write backward to protect unread values |
+| 9 | [3Sum](../../algorithms/15-3sum) | Reduce K-sum to a sorted pair search |
+| 10 | [4Sum](../../algorithms/18-4sum) | Add an anchor without changing the inner proof |
+| 11 | [Trapping Rain Water](../../algorithms/42-trapping-rain-water) | Settle a side using maintained state |
 
 ---
 
-## Pattern Recognition Guide
+## The Question Behind Every Move
 
-```text
-Need a pair in sorted input?
-→ Converging pointers
+Before every `left += 1` or `right -= 1`, answer all three questions:
 
-Need to compare mirrored positions?
-→ Converging pointers
+1. **What does this pointer mean?** For example, `write` may mean "the next output slot," not merely "a slow pointer."
+2. **What is already settled?** This might be an outside region, a completed output prefix, or a final sorted suffix.
+3. **Why can no skipped candidate be the answer?** This is the invariant or elimination argument.
 
-Need to filter or compact an array in place?
-→ Read/write pointers
-
-Need to combine two sorted inputs?
-→ One pointer per input
-
-Need a triplet or quadruplet?
-→ Fix anchors, then converge
-
-Need the longest or shortest valid contiguous range?
-→ Probably sliding window
-```
-
-| Signal | Pattern |
-|---|---|
-| Sorted array, find pair/triplet with target sum | [Opposite-Ends Converging](#1-opposite-ends-converging-sorted-array) |
-| Validate a palindrome or allow one deletion | [Palindrome Check / Skip](#2-palindrome-check--skip) |
-| Reverse or rotate in place | [Reverse / Rotate In-Place](#3-reverse--rotate-in-place) |
-| Remove values or duplicates in place | [Read/Write Pointers](#4-readwrite-pointers-in-place-filtering) |
-| Combine two sorted inputs | [Merge Two Sorted Sequences](#5-merge-two-sorted-sequences) |
-| 3Sum or 4Sum | [K-Sum Reduction](#6-k-sum-reduction-3sum--4sum) |
-| Trap water or maintain boundaries from both sides | [Running Max Walls](#7-running-max-walls-trapping-rain-water) |
+If a problem cannot answer the third question, it may be a sliding window, binary search, dynamic programming, or a different technique entirely.
 
 ---
 
-## Core Patterns
+## 1. Mirror And Swap
 
-### 1. Opposite-Ends Converging (sorted array)
+### Recognize It
 
-> **Signals:** sorted array, pair sum, Two Sum II, Container With Most Water, Boats to Save People
+Use two pointers at opposite ends when the problem asks about **symmetry** or **in-place reversal**:
 
-<PatternVizModal label="Opposite-Ends Converging">
-  <OppositeEndsViz />
+- "reads the same forward and backward"
+- "ignore punctuation or case"
+- "delete at most one character"
+- "reverse this mutable array in place"
+
+<PatternVizModal label="Mirror and Swap">
+  <ReverseRotateViz />
 </PatternVizModal>
 
-**Invariant:** if the answer exists, it remains within `[left, right]`. Each step safely eliminates one endpoint:
+### Pointer Jobs And Invariant
 
-- If `sum > target`, move `right` because the right value is too large.
-- If `sum < target`, move `left` because the left value is too small.
+```text
+left   next unresolved position from the front
+right  next unresolved position from the back
 
-```python
-def two_sum(numbers, target):
-    left, right = 0, len(numbers) - 1
-
-    while left < right:
-        total = numbers[left] + numbers[right]
-
-        if total == target:
-            return [left + 1, right + 1]
-        if total < target:
-            left += 1
-        else:
-            right -= 1
+Invariant: positions outside [left, right] have already been swapped
+or verified against their mirror.
 ```
 
-**Container With Most Water** has the same shape but a different movement rule. Move the shorter wall because it limits the current area; moving the taller wall cannot improve that limit while width decreases.
+For reversal, the outer characters belong in each other's final position. For a palindrome, a mismatch proves failure because those characters must match in every valid mirrored reading.
 
-```python
-def max_area(height):
-    left, right = 0, len(height) - 1
-    result = 0
+### Anchor Problem: Valid Palindrome
 
-    while left < right:
-        result = max(
-            result,
-            min(height[left], height[right]) * (right - left),
-        )
-
-        if height[left] < height[right]:
-            left += 1
-        else:
-            right -= 1
-
-    return result
-```
-
-**Boats to Save People** sorts first, then pairs the heaviest person with the lightest when possible:
-
-```python
-def num_rescue_boats(people, limit):
-    people.sort()
-    left, right = 0, len(people) - 1
-    boats = 0
-
-    while left <= right:
-        if people[left] + people[right] <= limit:
-            left += 1
-        right -= 1
-        boats += 1
-
-    return boats
-```
-
----
-
-### 2. Palindrome Check / Skip
-
-> **Signals:** valid palindrome, one allowed deletion, skip non-alphanumeric characters
+Start with [Reverse String](../../algorithms/344-reverse-string) to learn the raw motion. Then use the same motion in [Valid Palindrome](../../algorithms/125-valid-palindrome), where the only extra work is skipping characters that do not participate in the comparison.
 
 <PatternVizModal label="Palindrome Check">
   <PalindromeCheckViz />
 </PatternVizModal>
-
-Palindrome checks compare mirrored positions and shrink the unknown region from both ends.
 
 ```python
 def is_palindrome(s: str) -> bool:
@@ -267,11 +146,23 @@ def is_palindrome(s: str) -> bool:
     return True
 ```
 
-**Valid Palindrome II** allows one deletion. At the first mismatch, skip either side and test the remaining range:
+**Why both pointers move after a match:** those two positions have now been compared successfully. They can never affect a later decision, so the unknown region shrinks to the interior.
+
+### Deepen: Allow One Deletion
+
+[Valid Palindrome II](../../algorithms/680-valid-palindrome-ii) changes only the mismatch case. Up to the first mismatch, the normal palindrome invariant still holds. At that mismatch, exactly one deletion is allowed, so there are exactly two meaningful continuations:
+
+```text
+abca
+ ^ ^     b != c
+
+Skip b: check "ca"
+Skip c: check "bc"
+```
 
 ```python
 def valid_palindrome(s: str) -> bool:
-    def is_pal(left, right):
+    def is_palindrome_range(left: int, right: int) -> bool:
         while left < right:
             if s[left] != s[right]:
                 return False
@@ -280,98 +171,163 @@ def valid_palindrome(s: str) -> bool:
         return True
 
     left, right = 0, len(s) - 1
-
     while left < right:
         if s[left] != s[right]:
             return (
-                is_pal(left + 1, right)
-                or is_pal(left, right - 1)
+                is_palindrome_range(left + 1, right)
+                or is_palindrome_range(left, right - 1)
             )
         left += 1
         right -= 1
-
     return True
 ```
 
-The first mismatch is the only branch point. Passing index boundaries rather than slices also avoids allocating new strings.
+Do not slice strings for those checks when the intended solution is O(1) auxiliary space. Passing boundaries keeps the check in the original string.
+
+### Check Yourself
+
+- Why is `left < right` correct here rather than `left <= right`?
+- Why does the first mismatch create the only branch point in Valid Palindrome II?
+- What would change if two deletions were allowed?
 
 ---
 
-### 3. Reverse / Rotate In-Place
+## 2. Sorted-Pair Elimination
 
-> **Signals:** reverse in place, rotate by `k`, O(1) extra space
+### Recognize It
 
-<PatternVizModal label="Reverse / Rotate In-Place">
-  <ReverseRotateViz />
+Use this family when the input is sorted and the task asks for a pair that reaches a target. Sorting creates monotonic behavior: moving left raises the sum; moving right lowers it.
+
+<PatternVizModal label="Sorted Pair Elimination">
+  <OppositeEndsViz />
 </PatternVizModal>
 
+### Anchor Problem: Two Sum II
+
+[Two Sum II - Input Array Is Sorted](../../algorithms/167-two-sum-ii-input-array-is-sorted) is the cleanest version. Start at the widest range and compare the two endpoint values.
+
 ```python
-def reverse_string(s: list) -> None:
-    left, right = 0, len(s) - 1
+def two_sum(numbers: list[int], target: int) -> list[int]:
+    left, right = 0, len(numbers) - 1
 
     while left < right:
-        s[left], s[right] = s[right], s[left]
-        left += 1
-        right -= 1
-```
+        total = numbers[left] + numbers[right]
 
-**Rotate Array** uses three reversals:
-
-```python
-def rotate(nums: list, k: int) -> None:
-    if not nums:
-        return
-
-    k %= len(nums)
-
-    def reverse(left, right):
-        while left < right:
-            nums[left], nums[right] = nums[right], nums[left]
+        if total == target:
+            return [left + 1, right + 1]
+        if total < target:
             left += 1
+        else:
             right -= 1
 
-    reverse(0, len(nums) - 1)
-    reverse(0, k - 1)
-    reverse(k, len(nums) - 1)
+    return []
 ```
 
-The empty-input guard prevents division by zero in `k %= len(nums)`.
+### The Elimination Proof
+
+Assume `numbers` is sorted.
+
+| What you see | Safe move | Why it discards no solution |
+|---|---|---|
+| `numbers[left] + numbers[right] < target` | `left += 1` | `numbers[right]` is the largest available partner. Pairing `numbers[left]` with any interior value only makes the sum smaller. |
+| `numbers[left] + numbers[right] > target` | `right -= 1` | `numbers[left]` is the smallest available partner. Pairing `numbers[right]` with any interior value only makes the sum larger. |
+| Sum equals target | Return | The problem guarantees one answer. |
+
+The invariant is not "the answer is in the current range" by itself. It is: **if an answer exists, at least one answer remains in the current range because every removed endpoint has been proved impossible.**
+
+### Important Boundary: Unsorted Two Sum
+
+The same target-pair wording does not automatically mean two pointers. If original indices matter and the input is unsorted, sorting loses the requested positions. [Two Sum](../../algorithms/1-two-sum) belongs to Arrays and Hashing because a hash map preserves original indices in O(n) time.
+
+### Check Yourself
+
+- Why would moving `right` after a sum that is too small be unjustified?
+- Why does this take O(n), not O(n^2)?
+- If you sorted `(value, original_index)` pairs, what extra detail would you need to return?
 
 ---
 
-### 4. Read/Write Pointers (In-Place Filtering)
+## 3. Converging Pointers With A Greedy Proof
 
-> **Signals:** remove in place, compact values, move zeroes, return the new length
+### Recognize It
 
-<PatternVizModal label="Write Pointer — Remove Duplicates">
+[Container With Most Water](../../algorithms/11-container-with-most-water) also starts at both ends, but it is **not** a target-sum problem. The score is:
+
+```text
+area = min(height[left], height[right]) * (right - left)
+```
+
+The pointer layout looks like Two Sum II. The reason for moving is different.
+
+### Anchor Problem: Container With Most Water
+
+```python
+def max_area(height: list[int]) -> int:
+    left, right = 0, len(height) - 1
+    best = 0
+
+    while left < right:
+        best = max(best, min(height[left], height[right]) * (right - left))
+
+        if height[left] < height[right]:
+            left += 1
+        else:
+            right -= 1
+
+    return best
+```
+
+### Why Move The Shorter Wall?
+
+Suppose `height[left] <= height[right]`.
+
+- The current area is limited by `height[left]`.
+- Every pair that keeps this `left` wall has a smaller width after `right` moves inward.
+- Its limiting height can be at most `height[left]`, because that left wall has not changed.
+- Therefore no future pair that keeps this left wall can beat the current area.
+
+Move `left` and look for a taller limiting wall. Moving the taller right wall has no proof behind it: it reduces width while leaving the short limiting wall in place.
+
+### Compare The Two Opposite-Ends Families
+
+| Problem | What controls the move? | What gets eliminated? |
+|---|---|---|
+| Two Sum II | A sum is too small or too large in sorted input | The endpoint whose every possible partner fails the target |
+| Container With Most Water | The shorter wall limits the area | The endpoint whose height caps every narrower container |
+
+Same shape, different proof. This distinction prevents the common mistake of applying "move the smaller value" to every two-pointer problem.
+
+### Check Yourself
+
+- If the two heights are equal, why can either pointer move?
+- Why is it useful to begin at maximum width?
+- Which part of the formula gets worse on every iteration, and which part might improve?
+
+---
+
+## 4. Read/Write Compaction
+
+### Recognize It
+
+Reach for read/write pointers when the input array is also the output buffer:
+
+- "remove in place"
+- "return the new length"
+- "keep relative order"
+- "use O(1) extra space"
+
+One pointer reads every value. The other writes only values that belong in the result.
+
+<PatternVizModal label="Read/Write Compaction">
   <RemoveDupsViz />
 </PatternVizModal>
 
-- `read` examines the next input value.
-- `write` points to the next kept value’s destination.
+### Anchor Problem: Remove Duplicates From Sorted Array
 
-Because `write <= read`, assigning `nums[write] = nums[read]` cannot destroy unread input.
-
-**Remove Element:**
+In [Remove Duplicates from Sorted Array](../../algorithms/26-remove-duplicates-from-sorted-array), sorted order means a number is new precisely when it differs from the last value accepted into the prefix.
 
 ```python
-def remove_element(nums, value) -> int:
-    write = 0
-
-    for read in range(len(nums)):
-        if nums[read] != value:
-            nums[write] = nums[read]
-            write += 1
-
-    return write
-```
-
-**Invariant:** `nums[:write]` contains exactly the kept values from the input examined so far.
-
-**Remove Duplicates from Sorted Array:**
-
-```python
-def remove_duplicates(nums) -> int:
+def remove_duplicates(nums: list[int]) -> int:
     if not nums:
         return 0
 
@@ -385,111 +341,57 @@ def remove_duplicates(nums) -> int:
     return write
 ```
 
-**Retain at most `k` copies:**
+### The Invariant
 
-```python
-def retain_at_most_k(nums, k) -> int:
-    if k <= 0:
-        return 0
+After each iteration:
 
-    write = 0
-
-    for read in range(len(nums)):
-        if write < k or nums[read] != nums[write - k]:
-            nums[write] = nums[read]
-            write += 1
-
-    return write
+```text
+nums[:write] contains exactly the unique values seen so far, in final order.
+nums[write:read + 1] may contain stale values and does not matter yet.
+nums[read + 1:] has not been examined.
 ```
 
-For `k = 2`, compare the current value with the value two accepted positions behind it. If they differ, accepting the current value cannot create more than two copies.
+`write <= read`, so writing `nums[write] = nums[read]` cannot overwrite input that has not been read. The answer is the length of the valid prefix, not a newly allocated array.
+
+### Change One Rule
+
+Many compaction problems retain the same invariant and only change the keep rule:
+
+```python
+# Keep at most k copies in a sorted array.
+if write < k or nums[read] != nums[write - k]:
+    nums[write] = nums[read]
+    write += 1
+```
+
+For `k = 2`, comparing against the value two accepted positions behind prevents a third copy from entering the finished prefix.
+
+### Check Yourself
+
+- Why compare `nums[read]` with `nums[write - 1]` instead of `nums[read - 1]`?
+- What does the caller use after the function returns?
+- Why are values after `write` allowed to be anything?
 
 ---
 
-### 5. Merge Two Sorted Sequences
+## 5. Two-Input Traversal
 
-> **Signals:** merge sorted arrays, two ordered inputs, pre-allocated output space
+### Recognize It
 
-<PatternVizModal label="Merge Two Sequences">
-  <MergeTwoViz />
-</PatternVizModal>
+Use one pointer per input when the question asks you to consume, combine, compare, or interleave two sequences.
 
-A normal forward merge compares the smallest unprocessed values. If the output must overwrite `nums1`, writing from the front can destroy values that have not been compared. Fill from the back instead:
+The shared invariant is simple:
 
-```python
-def merge(nums1, m, nums2, n):
-    p1 = m - 1
-    p2 = n - 1
-    write = m + n - 1
+> Everything before each read pointer has been handled correctly.
 
-    while p1 >= 0 and p2 >= 0:
-        if nums1[p1] >= nums2[p2]:
-            nums1[write] = nums1[p1]
-            p1 -= 1
-        else:
-            nums1[write] = nums2[p2]
-            p2 -= 1
+The destination may be a new result, or it may be a position in one of the inputs.
 
-        write -= 1
+### Start: Merge Strings Alternately
 
-    while p2 >= 0:
-        nums1[write] = nums2[p2]
-        p2 -= 1
-        write -= 1
-```
-
-The pointers mean:
-
-```text
-p1    last unmerged real value in nums1
-p2    last unmerged value in nums2
-write next destination slot in nums1
-```
-
-This is often called a two-pointer solution even though it contains three pointer variables: `p1` and `p2` make the merge decision, while `write` tracks the output position.
-
-**Invariant:** everything to the right of `write` is already in its final sorted position.
-
-```text
-nums1 = [10, 20, 20, 40, 0, 0], m = 4
-nums2 = [1, 2],                  n = 2
-
-Start: p1=3 (40), p2=1 (2), write=5
-Turn 1: write 40 → [10, 20, 20, 40, 0, 40]
-Turn 2: write 20 → [10, 20, 20, 40, 20, 40]
-Turn 3: write 20 → [10, 20, 20, 20, 20, 40]
-Turn 4: write 10 → [10, 20, 10, 20, 20, 40]
-Leftovers:          [1, 2, 10, 20, 20, 40]
-```
-
-Only `nums2` needs a leftover loop:
-
-- If `nums2` is exhausted first, remaining `nums1` values are already correctly positioned.
-- If `nums1` is exhausted first, the remaining smaller `nums2` values must fill the prefix.
-
-**Boundary case: `nums1` is exhausted first.** The zero in `nums1` is only
-available capacity; because `m = 0`, it is not an input value:
-
-```text
-nums1 = [0], m = 0
-nums2 = [1], n = 1
-
-Start:  p1 = -1, p2 = 0, write = 0
-Main loop: skipped because p1 < 0
-Cleanup:  nums1[0] = nums2[0] = 1, then p2 = -1
-Result:   nums1 = [1]
-```
-
-This is the case that makes `while p2 >= 0` necessary. There are no original
-`nums1` values left to protect or move, but the remaining `nums2` values still
-need to be written into the prefix of `nums1`.
-
-The algorithm does not require `m >= n`; it only requires `nums1` to have total capacity `m + n`.
-
-**Merge Strings Alternately:**
+[Merge Strings Alternately](../../algorithms/1768-merge-strings-alternately) is intentionally simple. It teaches coordination without ordering or overwrite concerns.
 
 ```python
-def merge_alternately(word1, word2):
+def merge_alternately(word1: str, word2: str) -> str:
     i = j = 0
     result = []
 
@@ -501,32 +403,84 @@ def merge_alternately(word1, word2):
 
     result.append(word1[i:])
     result.append(word2[j:])
-    return ''.join(result)
+    return "".join(result)
 ```
+
+The cleanup appends whichever suffix remains. It is not an edge case bolted on afterward; it is part of handling all input.
+
+### Deepen: Merge Sorted Array In Place
+
+[Merge Sorted Array](../../algorithms/88-merge-sorted-array) adds two constraints:
+
+1. Take the larger remaining value so the output remains sorted.
+2. Store the answer in `nums1` without overwriting unread values.
+
+<PatternVizModal label="Merge Two Sorted Sequences">
+  <MergeTwoViz />
+</PatternVizModal>
+
+The second constraint determines the direction. Write from the back, where `nums1` has empty capacity.
+
+```python
+def merge(nums1: list[int], m: int, nums2: list[int], n: int) -> None:
+    p1 = m - 1
+    p2 = n - 1
+    write = m + n - 1
+
+    while p1 >= 0 and p2 >= 0:
+        if nums1[p1] >= nums2[p2]:
+            nums1[write] = nums1[p1]
+            p1 -= 1
+        else:
+            nums1[write] = nums2[p2]
+            p2 -= 1
+        write -= 1
+
+    while p2 >= 0:
+        nums1[write] = nums2[p2]
+        p2 -= 1
+        write -= 1
+```
+
+### The Invariant And The Leftover Rule
+
+```text
+p1     last unmerged real value from nums1
+p2     last unmerged value from nums2
+write  next final slot, filled from right to left
+
+Invariant: nums1[write + 1:] is in final sorted order.
+```
+
+Only `nums2` needs a cleanup loop. If `nums2` finishes first, the unmerged `nums1` values are already in their correct prefix positions. If `nums1` finishes first, the remaining `nums2` values still need to be copied.
+
+### Check Yourself
+
+- Why would a forward write be unsafe?
+- Why are there three pointer variables in a two-pointer solution?
+- What happens when `m = 0` and `nums1` contains only placeholder capacity?
 
 ---
 
-### 6. K-Sum Reduction (3Sum / 4Sum)
+## 6. Anchor Plus Pair Search
 
-> **Signals:** triplets or quadruplets summing to a target, unique results
+### Recognize It
 
-<PatternVizModal label="3Sum Reduction">
+Use this family for unique triplets, quadruplets, or general K-sum tasks. Sorting has two jobs:
+
+1. It gives the remaining pair search the monotonic behavior from Two Sum II.
+2. It puts duplicates next to each other, so they can be skipped deliberately.
+
+<PatternVizModal label="K-Sum Reduction">
   <KSumReductionViz />
 </PatternVizModal>
 
-Sort the input, fix one or more anchors, then reduce the remaining task to a converging pair search:
+### Anchor Problem: 3Sum
 
-- 3Sum: one anchor × O(n) pair search = O(n²)
-- 4Sum: two anchors × O(n) pair search = O(n³)
-
-Deduplication is part of correctness:
-
-1. Skip duplicate anchor values.
-2. After a match, move both pointers.
-3. Skip repeated values at both pointers.
+[3Sum](../../algorithms/15-3sum) fixes one number, then searches for the remaining pair in the sorted suffix.
 
 ```python
-def three_sum(nums):
+def three_sum(nums: list[int]) -> list[list[int]]:
     nums.sort()
     result = []
 
@@ -556,73 +510,57 @@ def three_sum(nums):
     return result
 ```
 
-**4Sum** follows the same structure with a second fixed anchor:
+### The Three Layers Of Correctness
 
-```python
-def four_sum(nums, target):
-    nums.sort()
-    result = []
+| Layer | Rule | Why it matters |
+|---|---|---|
+| Anchor | Skip an equal anchor value | The same first value would generate the same triples |
+| Pair search | Move left for a small sum and right for a large sum | Sorted order still proves each elimination |
+| Match | Move both, then skip duplicate pointer values | The recorded combination must not be recorded again |
 
-    for i in range(len(nums) - 3):
-        if i > 0 and nums[i] == nums[i - 1]:
-            continue
+Complexity is not O(n): the outer loop runs O(n) times and each pair sweep is O(n), for O(n^2) after sorting.
 
-        for j in range(i + 1, len(nums) - 2):
-            if j > i + 1 and nums[j] == nums[j - 1]:
-                continue
+### Deepen: 4Sum
 
-            left, right = j + 1, len(nums) - 1
+[4Sum](../../algorithms/18-4sum) changes one structural detail: fix a second anchor before running the same converging pair search.
 
-            while left < right:
-                total = (
-                    nums[i]
-                    + nums[j]
-                    + nums[left]
-                    + nums[right]
-                )
-
-                if total < target:
-                    left += 1
-                elif total > target:
-                    right -= 1
-                else:
-                    result.append([
-                        nums[i],
-                        nums[j],
-                        nums[left],
-                        nums[right],
-                    ])
-                    left += 1
-                    right -= 1
-
-                    while left < right and nums[left] == nums[left - 1]:
-                        left += 1
-                    while left < right and nums[right] == nums[right + 1]:
-                        right -= 1
-
-    return result
+```text
+3Sum: fix i              -> search left/right        -> O(n^2)
+4Sum: fix i, then fix j  -> search left/right        -> O(n^3)
 ```
+
+The duplicate rule repeats at every anchor level. Skip duplicate `i` values, skip duplicate `j` values relative to that `i`, and skip duplicate `left` and `right` values after a match.
+
+### Check Yourself
+
+- Why does `left` begin at `i + 1`?
+- Why are duplicates skipped after recording a match, not before moving the pointers?
+- Why can sorting change the space complexity even though the scan uses O(1) variables?
 
 ---
 
-### 7. Running Max Walls (Trapping Rain Water)
+## 7. Two-Sided State: Trapping Rain Water
 
-> **Signals:** elevation map, trapped water, boundaries on both sides
+### Recognize It
+
+Use this pattern when each position seems to need information from both directions, but the problem lets one side become final before the other is fully explored.
+
+[Trapping Rain Water](../../algorithms/42-trapping-rain-water) begins with the per-column formula:
+
+```text
+water at i = min(max height to its left, max height to its right) - height[i]
+```
+
+A direct solution stores two arrays of prefix and suffix maxima. The two-pointer version keeps only the two running maxima and settles the side whose boundary is known to be smaller.
 
 <PatternVizModal label="Trapping Rain Water">
   <TrappingWaterViz />
 </PatternVizModal>
 
-Water at position `i` is limited by:
-
-```text
-min(left_max, right_max) - height[i]
-```
-
-Maintain both maxima while processing whichever side is currently safe:
+### Anchor Problem: Trapping Rain Water
 
 ```python
-def trap(height):
+def trap(height: list[int]) -> int:
     left, right = 0, len(height) - 1
     left_max = right_max = 0
     water = 0
@@ -640,19 +578,31 @@ def trap(height):
     return water
 ```
 
-The running maxima replace two auxiliary arrays, reducing extra space from O(n) to O(1).
+### Why Is One Side Safe?
+
+If `left_max <= right_max`, then the final water level at `left` cannot exceed `left_max`: the right side already has a wall at least that high. Therefore `left_max - height[left]` is final. Process `left` and move it inward.
+
+The symmetric argument applies when `right_max < left_max`.
+
+This is not target-sum elimination and not "move the shorter current bar" by memorization. The decision comes from the **running maxima**, which summarize the processed boundaries.
+
+### Check Yourself
+
+- Why does `left_max <= right_max` make the right side sufficient without knowing its exact future maximum?
+- Why can the loop use `left <= right`?
+- What is the time and space cost of the prefix/suffix-array solution versus this version?
 
 ---
 
-## Two Pointers vs. Sliding Window
+## Do Not Confuse This With Sliding Window
 
-Sliding window often uses `left` and `right`, but it maintains state for an entire contiguous range.
+Sliding window also uses `left` and `right`, but its purpose is different. It maintains a contiguous range and the state of everything inside that range.
 
-| General two pointers | Sliding window |
+| Two pointers | Sliding window |
 |---|---|
-| Processes values at pointer positions | Maintains state for every value in a window |
-| Eliminates candidates or builds output | Expands and shrinks a contiguous valid range |
-| Pair, symmetry, merge, or in-place signals | Longest, shortest, “at most,” substring, or subarray signals |
+| Eliminates pairs, settles mirrored positions, merges inputs, or compacts output | Expands and shrinks one contiguous subarray or substring |
+| Pointer movement follows an endpoint proof or output invariant | Pointer movement restores a window condition |
+| Signals: pair, symmetry, two inputs, in-place | Signals: longest, shortest, at most, substring, subarray |
 
 ```python
 left = 0
@@ -667,17 +617,13 @@ for right in range(len(items)):
     update_answer(left, right)
 ```
 
-After the inner loop, `items[left:right + 1]` is valid. Treat sliding window as a related but separate pattern.
+If the task asks for the best valid contiguous range, start by considering sliding window rather than forcing a two-pointer elimination argument.
 
 ---
 
-## Beyond Arrays: Fast/Slow Pointers
+## Related But Separate: Fast And Slow Pointers
 
-Linked lists are not a prerequisite for array-based two pointers. After learning linked-list traversal, different pointer speeds support:
-
-- Finding the middle node
-- Detecting a cycle
-- Finding a cycle entrance
+Fast/slow pointers use different speeds rather than different positions at the ends of an array. They are common in linked lists for finding a middle node or detecting a cycle.
 
 ```python
 slow = fast = head
@@ -687,98 +633,51 @@ while fast is not None and fast.next is not None:
     fast = fast.next.next
 ```
 
-When `fast` reaches the end, `slow` is near the middle. In a cycle, a faster pointer eventually catches a slower one.
+It belongs to the broader two-pointer family, but it needs a different proof: a faster runner eventually catches a slower runner in a cycle. Learn it as a separate module after linked-list traversal.
 
 ---
 
-## Common Pitfalls
+## Debugging Checklist
 
-### Incorrect boundaries
+When a two-pointer solution is wrong, inspect these contracts rather than changing conditions at random:
 
-Use `left < right` when two distinct positions are required. Use `left <= right` when a single remaining position must also be processed.
-
-### Sorting destroys original indices
-
-Retain indices before sorting when the answer requires original positions:
-
-```python
-indexed = sorted(
-    (value, index)
-    for index, value in enumerate(nums)
-)
-```
-
-### Moving without proving safety
-
-Do not memorize “small sum means move left” without identifying the ordering property that makes it true.
-
-### Overwriting unread merge values
-
-An in-place merge into `nums1` must fill from the back unless extra storage or shifting is used.
-
-### Forgetting leftovers
-
-Remaining `nums2` values must be copied. Remaining `nums1` values are already in place.
-
-### Missing empty-input handling
-
-Operations such as `k %= len(nums)` and duplicate initialization need explicit guards.
-
-### Mishandling K-sum duplicates
-
-Skip duplicate anchors and duplicate pointer values after recording a match.
-
-### Hidden string allocations
-
-Python slicing creates new strings. Use index boundaries when O(1) auxiliary space matters.
-
-### Assuming two pointers always means O(n)
-
-Sorting, anchors, and nested scans affect total complexity. State the full cost.
-
----
-
-## Decision Guide: Which Pointer Strategy?
-
-| Question | Strategy |
+| Symptom | Question to ask |
 |---|---|
-| Sorted input and a pair target? | Opposite-ends converging |
-| Mirror symmetry? | Converging comparison |
-| In-place filtering or compaction? | Read/write pointers |
-| Two sorted inputs to combine? | One pointer per input; back-fill if in place |
-| Three or more values summing to a target? | Sort, fix anchors, then converge |
-| Heights and boundaries on both sides? | Running maxima with left/right pointers |
-| Best contiguous range? | Sliding window |
+| Missed pair or duplicate work | Did I prove the endpoint I removed cannot participate in an answer? |
+| Off-by-one result | Does a single remaining position need processing (`<=`) or do I require two distinct positions (`<`)? |
+| Wrong in-place array | Is the valid output exactly `nums[:write]`? |
+| Merge loses values | Am I writing into a location that one of my read pointers still needs? |
+| Duplicate 3Sum or 4Sum results | Did I skip equal values at every anchor level and after matches? |
+| Correct time, unexpected memory | Did sorting, slicing, a cleaned string, or a result buffer allocate extra storage? |
+| A move feels memorized | What monotonic property, greedy bound, or invariant makes it safe? |
 
 ---
 
 ## Complexity Reference
 
-| Pattern | Time | Extra space | Key requirement |
+| Family | Time | Extra space | Main reason |
 |---|---|---|---|
-| Sorted pair convergence | O(n) | O(1) | Sorted input or another monotonic rule |
-| Palindrome check | O(n) | O(1) | Mirror comparison |
-| Reverse in place | O(n) | O(1) | Mutable sequence |
-| Merge sorted, back-fill | O(m+n) | O(1) | `nums1` has capacity `m+n` |
-| Read/write filtering | O(n) | O(1) | Local keep/reject rule |
-| 3Sum | O(n²) | Sorting-dependent | Sort + one anchor |
-| 4Sum | O(n³) | Sorting-dependent | Sort + two anchors |
-| Trapping Rain Water | O(n) | O(1) | Safe-side running-max invariant |
+| Mirror comparison or reversal | O(n) | O(1) | Each endpoint moves inward once |
+| Sorted-pair elimination | O(n) | O(1) | Each pointer only moves in one direction |
+| Container With Most Water | O(n) | O(1) | One limiting endpoint is eliminated each turn |
+| Read/write compaction | O(n) | O(1) | Read scans once; write never moves backward |
+| Merge two sequences | O(m + n) | O(1) for in-place merge | Each input position is consumed once |
+| 3Sum | O(n^2) | Sorting-dependent | O(n) anchors times O(n) pair scan |
+| 4Sum | O(n^3) | Sorting-dependent | O(n^2) anchors times O(n) pair scan |
+| Trapping Rain Water | O(n) | O(1) | Each side is finalized once |
 
-For 3Sum and 4Sum, sorting may use O(log n) or O(n) auxiliary space depending on the language and implementation. Output storage is not included.
+Sorting may use O(log n) or O(n) auxiliary space depending on the language and implementation. Output storage is not included in the table.
 
 ---
 
-## Recall Checklist
+## Final Recall
 
-Before coding, explain:
+Before coding any two-pointer problem, say these answers out loud:
 
 1. What does each pointer represent?
-2. Which region is already processed?
-3. What invariant remains true?
-4. Why is the next movement safe?
-5. Does every iteration make progress?
-6. Should the loop use `<` or `<=`?
-7. Do sorting, duplicates, empty inputs, or original indices need special handling?
+2. What region or output is already final?
+3. What exact fact makes the next move safe?
+4. Does every iteration make progress?
+5. What changes for duplicates, empty input, original indices, or in-place output?
 
-If these answers are clear, the code is usually the easy part.
+If you can explain the move, you can rebuild the implementation. If you cannot, solve a smaller problem in the same family before moving on.

--- a/scripts/generate_problems.py
+++ b/scripts/generate_problems.py
@@ -41,6 +41,7 @@ SLUG_OVERRIDES: dict[str, str] = {
     "range_query_sum_2d_immutable": "range-sum-query-2d-immutable",
     "two_sum2": "two-sum-ii-input-array-is-sorted",
     "three_sum": "3sum",
+    "four_sum": "4sum",
     "max_area": "container-with-most-water",
     "max_profit": "best-time-to-buy-and-sell-stock",
     "longest_substring": "longest-substring-without-repeating-characters",

--- a/scripts/run_postgres_sql.sh
+++ b/scripts/run_postgres_sql.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <test-file.sql>" >&2
+  exit 1
+fi
+
+test_file="$1"
+if [[ ! -f "$test_file" ]]; then
+  echo "SQL test file not found: $test_file" >&2
+  exit 1
+fi
+
+if [[ -n "${POSTGRES_BIN:-}" ]]; then
+  postgres_bin="$POSTGRES_BIN"
+elif command -v brew >/dev/null 2>&1; then
+  postgres_bin="$(brew --prefix postgresql@17)/bin"
+else
+  echo "Set POSTGRES_BIN to your PostgreSQL 17 bin directory." >&2
+  exit 1
+fi
+
+if [[ ! -x "$postgres_bin/psql" || ! -x "$postgres_bin/pg_isready" ]]; then
+  echo "PostgreSQL 17 tools were not found in $postgres_bin." >&2
+  exit 1
+fi
+
+if ! "$postgres_bin/pg_isready" -q; then
+  echo "PostgreSQL 17 is not running. Start it with: brew services start postgresql@17" >&2
+  exit 1
+fi
+
+exec "$postgres_bin/psql" -v ON_ERROR_STOP=1 -d "${SQL_DATABASE:-postgres}" -f "$test_file"

--- a/src/leetcode/two_pointers/four_sum.py
+++ b/src/leetcode/two_pointers/four_sum.py
@@ -1,0 +1,47 @@
+from typing import List
+
+
+class Solution:
+    def fourSum(self, nums: List[int], target: int) -> List[List[int]]:
+        result = []
+        # Sorting makes pointer movements predictable and puts duplicates together.
+        nums.sort()
+        n = len(nums)
+
+        # Fix the first value, leaving three later positions for j, left, and right.
+        for i in range(n - 3):
+            # The same first value would produce the same set of quadruplets.
+            if i > 0 and nums[i] == nums[i - 1]:
+                continue
+
+            # Fix the second value, leaving a pair for the two-pointer search.
+            for j in range(i + 1, n - 2):
+                # Skip only repeats at this j level; nums[j] may equal nums[i].
+                if j > i + 1 and nums[j] == nums[j - 1]:
+                    continue
+
+                left, right = j + 1, n - 1
+
+                while left < right:
+                    four_sum = nums[i] + nums[j] + nums[left] + nums[right]
+
+                    if four_sum < target:
+                        # A larger left value is the only way to increase this sum.
+                        left += 1
+                    elif four_sum > target:
+                        # A smaller right value is the only way to decrease this sum.
+                        right -= 1
+                    else:
+                        result.append([nums[i], nums[j], nums[left], nums[right]])
+
+                        # Move past this pair before skipping equal values to keep
+                        # every quadruplet unique.
+                        left += 1
+                        right -= 1
+
+                        while left < right and nums[left] == nums[left - 1]:
+                            left += 1
+                        while left < right and nums[right] == nums[right + 1]:
+                            right -= 1
+
+        return result

--- a/src/sql/README.md
+++ b/src/sql/README.md
@@ -1,0 +1,28 @@
+# SQL Exercises
+
+Each exercise has three files:
+
+- `<problem>.sql` is the answer rendered on the Astro site.
+- `<problem>.fixture.sql` creates deterministic local tables and data.
+- `<problem>.test.sql` runs the fixture and answer together.
+
+Run PostgreSQL exercises from the repository root:
+
+```bash
+brew services start postgresql@17
+./scripts/run_postgres_sql.sh src/sql/postgres/joins/customers_without_orders.test.sql
+```
+
+Run SQLite exercises from the repository root:
+
+```bash
+sqlite3 :memory: < src/sql/sqlite/aggregation/monthly_paid_revenue.test.sql
+```
+
+The runner defaults to the local `postgres` database. Override it with `SQL_DATABASE` if you prefer another local database:
+
+```bash
+SQL_DATABASE=mental_gym ./scripts/run_postgres_sql.sh src/sql/postgres/joins/customers_without_orders.test.sql
+```
+
+Each test runs inside a transaction and rolls back afterward, so the fixtures leave no tables or rows in the database.

--- a/src/sql/postgres/joins/customers_without_orders.fixture.sql
+++ b/src/sql/postgres/joins/customers_without_orders.fixture.sql
@@ -1,0 +1,24 @@
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS customers;
+
+CREATE TABLE customers (
+  customer_id INTEGER PRIMARY KEY,
+  customer_name TEXT NOT NULL
+);
+
+CREATE TABLE orders (
+  order_id INTEGER PRIMARY KEY,
+  customer_id INTEGER NOT NULL REFERENCES customers(customer_id),
+  total_cents INTEGER NOT NULL
+);
+
+INSERT INTO customers (customer_id, customer_name) VALUES
+  (1, 'Ada'),
+  (2, 'Brianna'),
+  (3, 'Chen'),
+  (4, 'Darius');
+
+INSERT INTO orders (order_id, customer_id, total_cents) VALUES
+  (101, 1, 2400),
+  (102, 1, 1800),
+  (103, 3, 990);

--- a/src/sql/postgres/joins/customers_without_orders.sql
+++ b/src/sql/postgres/joins/customers_without_orders.sql
@@ -1,0 +1,7 @@
+SELECT
+  c.customer_id,
+  c.customer_name
+FROM customers AS c
+LEFT JOIN orders AS o ON o.customer_id = c.customer_id
+WHERE o.order_id IS NULL
+ORDER BY c.customer_id;

--- a/src/sql/postgres/joins/customers_without_orders.test.sql
+++ b/src/sql/postgres/joins/customers_without_orders.test.sql
@@ -1,0 +1,5 @@
+\set ON_ERROR_STOP on
+BEGIN;
+\ir customers_without_orders.fixture.sql
+\ir customers_without_orders.sql
+ROLLBACK;

--- a/src/sql/postgres/postgresql/latest_event_per_device.fixture.sql
+++ b/src/sql/postgres/postgresql/latest_event_per_device.fixture.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS device_events;
+
+CREATE TABLE device_events (
+  event_id INTEGER PRIMARY KEY,
+  device_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  occurred_at TIMESTAMP NOT NULL
+);
+
+INSERT INTO device_events (event_id, device_id, event_type, occurred_at) VALUES
+  (1, 'sensor-a', 'online', '2026-01-04 09:00:00'),
+  (2, 'sensor-a', 'offline', '2026-01-04 10:15:00'),
+  (3, 'sensor-b', 'online', '2026-01-04 08:45:00'),
+  (4, 'sensor-b', 'offline', '2026-01-04 08:45:00'),
+  (5, 'sensor-b', 'online', '2026-01-04 08:45:00'),
+  (6, 'sensor-c', 'maintenance', '2026-01-05 11:30:00');

--- a/src/sql/postgres/postgresql/latest_event_per_device.sql
+++ b/src/sql/postgres/postgresql/latest_event_per_device.sql
@@ -1,0 +1,5 @@
+SELECT DISTINCT ON (device_id)
+  device_id,
+  event_type
+FROM device_events
+ORDER BY device_id, occurred_at DESC, event_id DESC;

--- a/src/sql/postgres/postgresql/latest_event_per_device.test.sql
+++ b/src/sql/postgres/postgresql/latest_event_per_device.test.sql
@@ -1,0 +1,5 @@
+\set ON_ERROR_STOP on
+BEGIN;
+\ir latest_event_per_device.fixture.sql
+\ir latest_event_per_device.sql
+ROLLBACK;

--- a/src/sql/sqlite/aggregation/monthly_paid_revenue.fixture.sql
+++ b/src/sql/sqlite/aggregation/monthly_paid_revenue.fixture.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS purchases;
+
+CREATE TABLE purchases (
+  purchase_id INTEGER PRIMARY KEY,
+  placed_at TEXT NOT NULL,
+  status TEXT NOT NULL,
+  amount_cents INTEGER NOT NULL
+);
+
+INSERT INTO purchases (purchase_id, placed_at, status, amount_cents) VALUES
+  (1, '2026-01-03 12:00:00', 'paid', 1200),
+  (2, '2026-01-08 09:30:00', 'pending', 990),
+  (3, '2026-01-26 18:45:00', 'paid', 2900),
+  (4, '2026-02-02 14:15:00', 'paid', 2800),
+  (5, '2026-02-18 10:05:00', 'refunded', 700);

--- a/src/sql/sqlite/aggregation/monthly_paid_revenue.sql
+++ b/src/sql/sqlite/aggregation/monthly_paid_revenue.sql
@@ -1,0 +1,7 @@
+SELECT
+  strftime('%Y-%m', placed_at) AS month,
+  SUM(amount_cents) AS revenue_cents
+FROM purchases
+WHERE status = 'paid'
+GROUP BY month
+ORDER BY month;

--- a/src/sql/sqlite/aggregation/monthly_paid_revenue.test.sql
+++ b/src/sql/sqlite/aggregation/monthly_paid_revenue.test.sql
@@ -1,0 +1,4 @@
+BEGIN;
+.read src/sql/sqlite/aggregation/monthly_paid_revenue.fixture.sql
+.read src/sql/sqlite/aggregation/monthly_paid_revenue.sql
+ROLLBACK;

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -28,15 +28,26 @@ The script reads `src/leetcode/<category>/<problem>.py`, fetches problem metadat
 
 ### Content sources
 
-The site has three content sources that feed different pages:
+The site has four content sources that feed different pages:
 
 | Source | How it's used |
 |---|---|
 | `src/data/problems.ts` | Auto-generated. Drives all algorithm problem pages via `getStaticPaths()`. |
 | `src/data/mlProblems.ts` | Hand-authored. ML coding interview problems with prompts, hints, and follow-ups. |
+| `src/data/sqlProblems.ts` | Hand-authored SQL exercise metadata. Each imports its reference answer from `src/sql/`. |
 | `../notes/` (outside `web/`) | Markdown files collected via Astro content collections. Rendered with KaTeX math support. |
 
 The notes loader globs `**/*.{md,mdx}`, so both extensions are valid. Use `.mdx` **only** when a note imports an Astro component (e.g. `arrays_and_hashing.mdx`, `two_pointers.mdx` embed the `notes/*Viz.astro` visualizations); keep prose-only notes as `.md` so they stay on the lighter Markdown pipeline. Frontmatter is identical for both: `title`, `description`, `category`, optional `order`.
+
+### SQL practice
+
+SQL answers live in `src/sql/`, next to deterministic fixtures and test harnesses:
+
+- `<problem>.sql` is the reference answer rendered on the Astro site.
+- `<problem>.fixture.sql` creates local test tables and data.
+- `<problem>.test.sql` runs the fixture, then the answer.
+
+PostgreSQL exercises run locally with Homebrew PostgreSQL 17 through `scripts/run_postgres_sql.sh`; SQLite exercises run with `sqlite3`. The PostgreSQL service must be started with `brew services start postgresql@17`. See `src/sql/README.md` for commands. Add a problem to `src/data/sqlProblems.ts`; the `/sql/[slug]` routes and Problems Bank SQL tab are generated from that data.
 
 ### Teaching motion framework
 
@@ -64,8 +75,9 @@ Client-side only — no server. State is stored in **IndexedDB** (`mental-gym-sr
 | Route pattern | File | What it renders |
 |---|---|---|
 | `/` | `src/pages/index.astro` | Home dashboard with stats |
-| `/problems` | `src/pages/problems/index.astro` | Problem list (tabs: algorithms / ML) |
+| `/problems` | `src/pages/problems/index.astro` | Problem list (tabs: algorithms / ML / SQL) |
 | `/algorithms/[slug]` | `src/pages/algorithms/[slug].astro` | Individual algorithm problem + optional animation |
 | `/machine-learning/[slug]` | `src/pages/machine-learning/[slug].astro` | ML problem with prompt/hints |
+| `/sql/[slug]` | `src/pages/sql/[slug].astro` | SQL prompt, local runner command, and source-file answer |
 | `/notes` | `src/pages/notes/index.astro` | Notes index |
 | `/notes/[slug]` | `src/pages/notes/[slug].astro` | Individual note (markdown + KaTeX) |

--- a/web/src/components/DueForReview.astro
+++ b/web/src/components/DueForReview.astro
@@ -14,6 +14,7 @@
 <script>
   import { getDueRecords } from "../scripts/sr-db";
   import { statusOf, daysUntilDue, todayISO } from "../scripts/sr-scheduler";
+  import { withBase } from "../lib/url";
 
   class DueForReviewElement extends HTMLElement {
     connectedCallback() {
@@ -40,10 +41,13 @@
         .map((r) => {
           const status = statusOf(r, today);
           const days = daysUntilDue(r, today);
-          const href =
+          const path =
             r.domain === "algorithms"
               ? `/algorithms/${r.slug}/`
-              : `/machine-learning/${r.slug}/`;
+              : r.domain === "ml"
+                ? `/machine-learning/${r.slug}/`
+                : `/sql/${r.slug}/`;
+          const href = withBase(path);
           const overdueDays = Math.abs(days);
           const statusText =
             status === "overdue"

--- a/web/src/components/LastVisited.astro
+++ b/web/src/components/LastVisited.astro
@@ -12,7 +12,7 @@
  */
 interface Props {
 	title: string;
-	kind: "Algorithms" | "Machine Learning" | "Notes";
+	kind: "Algorithms" | "Machine Learning" | "Notes" | "SQL";
 }
 
 const { title, kind } = Astro.props;

--- a/web/src/components/ProgressHistory.astro
+++ b/web/src/components/ProgressHistory.astro
@@ -73,7 +73,7 @@ import ActivityHeatmap from "./ActivityHeatmap.astro";
 
 				const domains = this.querySelector<HTMLElement>("[data-domains]");
 				if (domains) {
-					domains.innerHTML = `<div><span>Algorithms</span><strong>${history.domainCounts.algorithms}</strong></div><div><span>Machine Learning</span><strong>${history.domainCounts.ml}</strong></div>`;
+					domains.innerHTML = `<div><span>Algorithms</span><strong>${history.domainCounts.algorithms}</strong></div><div><span>Machine Learning</span><strong>${history.domainCounts.ml}</strong></div><div><span>SQL</span><strong>${history.domainCounts.sql}</strong></div>`;
 				}
 
 				await customElements.whenDefined("activity-heatmap");

--- a/web/src/components/ProgressSummary.astro
+++ b/web/src/components/ProgressSummary.astro
@@ -176,7 +176,9 @@ const { detailed = false } = Astro.props;
               const path =
                 record.domain === "algorithms"
                   ? `/algorithms/${encodeURIComponent(record.slug)}/`
-                  : `/machine-learning/${encodeURIComponent(record.slug)}/`;
+                  : record.domain === "ml"
+                    ? `/machine-learning/${encodeURIComponent(record.slug)}/`
+                    : `/sql/${encodeURIComponent(record.slug)}/`;
               const href = withBase(path);
               const state = record.dueDate < todayISO() ? "Overdue" : "Due today";
 

--- a/web/src/components/RecallRating.astro
+++ b/web/src/components/RecallRating.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  domain: "algorithms" | "ml";
+  domain: "algorithms" | "ml" | "sql";
   slug: string;
   title: string;
   difficulty: string;
@@ -60,7 +60,7 @@ const { domain, slug, title, difficulty, group } = Astro.props;
 
   class RecallRatingElement extends HTMLElement {
     connectedCallback() {
-      const domain = this.dataset.domain as "algorithms" | "ml";
+      const domain = this.dataset.domain as "algorithms" | "ml" | "sql";
       const slug = this.dataset.slug!;
       const title = this.dataset.title!;
       const difficulty = this.dataset.difficulty!;

--- a/web/src/data/problems.ts
+++ b/web/src/data/problems.ts
@@ -3510,6 +3510,100 @@ end`,
     sourceUrl: "https://leetcode.com/problems/3sum/",
   },
   {
+    id: "18",
+    slug: "18-4sum",
+    leetcodeSlug: "4sum",
+    title: "4Sum",
+    difficulty: "Medium",
+    group: "Two Pointers",
+    topics: ["array", "two-pointers", "sorting"],
+    description: `<p>Given an array <code>nums</code> of <code>n</code> integers, return <em>an array of all the <strong>unique</strong> quadruplets</em> <code>[nums[a], nums[b], nums[c], nums[d]]</code> such that:</p>
+
+<ul>
+	<li><code>0 &lt;= a, b, c, d&nbsp;&lt; n</code></li>
+	<li><code>a</code>, <code>b</code>, <code>c</code>, and <code>d</code> are <strong>distinct</strong>.</li>
+	<li><code>nums[a] + nums[b] + nums[c] + nums[d] == target</code></li>
+</ul>
+
+<p>You may return the answer in <strong>any order</strong>.</p>
+
+<p>&nbsp;</p>
+<p><strong class="example">Example 1:</strong></p>
+
+<pre>
+<strong>Input:</strong> nums = [1,0,-1,0,-2,2], target = 0
+<strong>Output:</strong> [[-2,-1,1,2],[-2,0,0,2],[-1,0,0,1]]
+</pre>
+
+<p><strong class="example">Example 2:</strong></p>
+
+<pre>
+<strong>Input:</strong> nums = [2,2,2,2,2], target = 8
+<strong>Output:</strong> [[2,2,2,2]]
+</pre>
+
+<p>&nbsp;</p>
+<p><strong>Constraints:</strong></p>
+
+<ul>
+	<li><code>1 &lt;= nums.length &lt;= 200</code></li>
+	<li><code>-10<sup>9</sup> &lt;= nums[i] &lt;= 10<sup>9</sup></code></li>
+	<li><code>-10<sup>9</sup> &lt;= target &lt;= 10<sup>9</sup></code></li>
+</ul>
+`,
+    solutions: {
+      python: `from typing import List
+
+
+class Solution:
+    def fourSum(self, nums: List[int], target: int) -> List[List[int]]:
+        result = []
+        # Sorting makes pointer movements predictable and puts duplicates together.
+        nums.sort()
+        n = len(nums)
+
+        # Fix the first value, leaving three later positions for j, left, and right.
+        for i in range(n - 3):
+            # The same first value would produce the same set of quadruplets.
+            if i > 0 and nums[i] == nums[i - 1]:
+                continue
+
+            # Fix the second value, leaving a pair for the two-pointer search.
+            for j in range(i + 1, n - 2):
+                # Skip only repeats at this j level; nums[j] may equal nums[i].
+                if j > i + 1 and nums[j] == nums[j - 1]:
+                    continue
+
+                left, right = j + 1, n - 1
+
+                while left < right:
+                    four_sum = nums[i] + nums[j] + nums[left] + nums[right]
+
+                    if four_sum < target:
+                        # A larger left value is the only way to increase this sum.
+                        left += 1
+                    elif four_sum > target:
+                        # A smaller right value is the only way to decrease this sum.
+                        right -= 1
+                    else:
+                        result.append([nums[i], nums[j], nums[left], nums[right]])
+
+                        # Move past this pair before skipping equal values to keep
+                        # every quadruplet unique.
+                        left += 1
+                        right -= 1
+
+                        while left < right and nums[left] == nums[left - 1]:
+                            left += 1
+                        while left < right and nums[right] == nums[right + 1]:
+                            right -= 1
+
+        return result`,
+      julia: ``,
+    },
+    sourceUrl: "https://leetcode.com/problems/4sum/",
+  },
+  {
     id: "26",
     slug: "26-remove-duplicates-from-sorted-array",
     leetcodeSlug: "remove-duplicates-from-sorted-array",

--- a/web/src/data/sqlProblems.ts
+++ b/web/src/data/sqlProblems.ts
@@ -1,0 +1,88 @@
+import customersWithoutOrders from "../../../src/sql/postgres/joins/customers_without_orders.sql?raw";
+import latestEventPerDevice from "../../../src/sql/postgres/postgresql/latest_event_per_device.sql?raw";
+import monthlyPaidRevenue from "../../../src/sql/sqlite/aggregation/monthly_paid_revenue.sql?raw";
+
+export type SQLDialect = "postgres" | "sqlite";
+export type SQLDifficulty = "Easy" | "Medium" | "Hard";
+
+export interface SQLProblem {
+	id: string;
+	slug: string;
+	title: string;
+	difficulty: SQLDifficulty;
+	category: string;
+	tags: string[];
+	dialect: SQLDialect;
+	summary: string;
+	prompt: string;
+	hints: string[];
+	solution: string;
+	testFile: string;
+	status: "Completed";
+}
+
+export const sqlProblems: SQLProblem[] = [
+	{
+		id: "SQL 01",
+		slug: "customers-without-orders",
+		title: "Customers Without Orders",
+		difficulty: "Easy",
+		category: "Joins",
+		tags: ["postgresql", "left join", "null"],
+		dialect: "postgres",
+		summary:
+			"Find every customer who has not placed an order, returning their ID and name in ID order.",
+		prompt:
+			"The tables below contain customers and their orders. Write a query that returns each customer with no matching order. Return customer_id and customer_name, ordered by customer_id.",
+		hints: [
+			"Start from customers so people with no orders remain candidates.",
+			"After an outer join, unmatched values on the orders side are NULL.",
+			"Use an explicit ORDER BY so the result has a stable order.",
+		],
+		solution: customersWithoutOrders,
+		testFile: "src/sql/postgres/joins/customers_without_orders.test.sql",
+		status: "Completed",
+	},
+	{
+		id: "SQL 02",
+		slug: "latest-event-per-device",
+		title: "Latest Event Per Device",
+		difficulty: "Medium",
+		category: "PostgreSQL",
+		tags: ["postgresql", "distinct on", "ordering"],
+		dialect: "postgres",
+		summary:
+			"Use PostgreSQL's DISTINCT ON to select the most recent event for every device.",
+		prompt:
+			"Return one row per device: its device_id and the event_type from its latest event. If two events have the same timestamp, choose the one with the larger event_id. Sort the final result by device_id.",
+		hints: [
+			"DISTINCT ON keeps the first row in each ordered device_id group.",
+			"The DISTINCT ON expression must lead the ORDER BY list.",
+			"Add event_id DESC after the timestamp to make ties deterministic.",
+		],
+		solution: latestEventPerDevice,
+		testFile: "src/sql/postgres/postgresql/latest_event_per_device.test.sql",
+		status: "Completed",
+	},
+	{
+		id: "SQL 03",
+		slug: "monthly-paid-revenue",
+		title: "Monthly Paid Revenue",
+		difficulty: "Medium",
+		category: "SQLite",
+		tags: ["sqlite", "aggregation", "strftime"],
+		dialect: "sqlite",
+		summary:
+			"Aggregate completed purchases by calendar month using SQLite date functions.",
+		prompt:
+			"Return the monthly revenue from paid purchases only. The result must contain month in YYYY-MM form and revenue_cents, ordered from earliest to latest month.",
+		hints: [
+			"Filter to paid purchases before grouping.",
+			"SQLite's strftime can extract a YYYY-MM value from ISO-style timestamps.",
+			"SUM returns the total for each group.",
+		],
+		solution: monthlyPaidRevenue,
+		testFile: "src/sql/sqlite/aggregation/monthly_paid_revenue.test.sql",
+		status: "Completed",
+	},
+];

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -39,7 +39,7 @@ const pathname = stripBase(Astro.url.pathname);
 			<div class="container">
 				<a class="brand" href={withBase("/")}>Mental Gym</a>
 				<nav>
-					<a href={withBase("/problems")} class={pathname.startsWith("/problems") || pathname.startsWith("/algorithms") || pathname.startsWith("/machine-learning") || pathname.startsWith("/system-design") ? "active" : ""}
+					<a href={withBase("/problems")} class={pathname.startsWith("/problems") || pathname.startsWith("/algorithms") || pathname.startsWith("/machine-learning") || pathname.startsWith("/sql") || pathname.startsWith("/system-design") ? "active" : ""}
 						>Practice</a
 					>
 					<a href={withBase("/notes")} class={pathname.startsWith("/notes") ? "active" : ""}

--- a/web/src/pages/problems/index.astro
+++ b/web/src/pages/problems/index.astro
@@ -1,6 +1,7 @@
 ---
 import { problems } from "../../data/problems";
 import { mlProblems } from "../../data/mlProblems";
+import { sqlProblems } from "../../data/sqlProblems";
 import DueForReview from "../../components/DueForReview.astro";
 import SRDataManager from "../../components/SRDataManager.astro";
 import ResumeRow from "../../components/ResumeRow.astro";
@@ -28,13 +29,22 @@ const mlByCategory = Object.fromEntries(
 		mlProblems.filter((problem) => problem.category === category),
 	]),
 );
+
+// SQL
+const sqlCategories = [...new Set(sqlProblems.map((problem) => problem.category))];
+const sqlByCategory = Object.fromEntries(
+	sqlCategories.map((category) => [
+		category,
+		sqlProblems.filter((problem) => problem.category === category),
+	]),
+);
 ---
 
 <Layout title="Problems | Mental Gym">
 	<div class="page-header">
 		<h1>Problems Bank</h1>
 		<p class="subtitle">
-			{problems.length} algorithms and {mlProblems.length} ML interview questions
+			{problems.length} algorithms, {mlProblems.length} ML, and {sqlProblems.length} SQL interview questions
 		</p>
 	</div>
 
@@ -45,6 +55,7 @@ const mlByCategory = Object.fromEntries(
 	<div class="section-tabs">
 		<button class="section-tab active" data-target="algo-section">Algorithms</button>
 		<button class="section-tab" data-target="ml-section">Machine Learning</button>
+		<button class="section-tab" data-target="sql-section">SQL</button>
 		<button class="section-tab" data-target="sd-section">System Design</button>
 	</div>
 
@@ -192,6 +203,62 @@ const mlByCategory = Object.fromEntries(
 			))
 		}
 	</div>
+
+	<div id="sql-section" class="problem-section hidden">
+		<div class="ml-intro">
+			<p>
+				Reference answers are tracked as <code>.sql</code> files and rendered here. Run
+				fixtures locally with PostgreSQL 17 or <code>sqlite3</code> for SQLite.
+			</p>
+		</div>
+
+		{
+			sqlCategories.map((category) => (
+				<section
+					class="group"
+					id={`sql-${category.toLowerCase().replace(/\s+&?\s*/g, "-")}`}
+				>
+					<h2 class="group-title">{category}</h2>
+					<table class="problem-table">
+						<thead>
+							<tr>
+								<th class="col-id">#</th>
+								<th class="col-title">Problem</th>
+								<th class="col-diff">Difficulty</th>
+								<th class="col-review">Review</th>
+								<th class="col-tags">Topics</th>
+							</tr>
+						</thead>
+						<tbody>
+							{sqlByCategory[category].map((problem) => (
+								<tr data-sr-key={`sql:${problem.slug}`}>
+									<td class="col-id muted">{problem.id}</td>
+									<td class="col-title">
+										<div class="problem-copy">
+											<a class="problem-name" href={withBase(`/sql/${problem.slug}/`)}>
+												{problem.title}
+											</a>
+											<span class="problem-summary">{problem.summary}</span>
+										</div>
+									</td>
+									<td class="col-diff">
+										<span class={`badge ${problem.difficulty.toLowerCase()}`}>
+											{problem.difficulty}
+										</span>
+									</td>
+									<td class="col-review" data-sr-pill />
+									<td class="col-tags">
+										<span class="tag">{problem.dialect === "postgres" ? "PostgreSQL" : "SQLite"}</span>
+										{problem.tags.slice(0, 2).map((tag) => <span class="tag">{tag}</span>)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+			))
+		}
+	</div>
 </Layout>
 
 <script>
@@ -223,8 +290,10 @@ const mlByCategory = Object.fromEntries(
 	sessionStorage.removeItem("problems-tab");
 
 	const target = hash.startsWith("#ml-") || requestedTab === "ml" ? "ml-section"
+		: hash.startsWith("#sql-") || requestedTab === "sql" ? "sql-section"
 		: hash.startsWith("#sd-") || requestedTab === "system-design" ? "sd-section"
 		: stored === "ml" ? "ml-section"
+		: stored === "sql" ? "sql-section"
 		: stored === "system-design" ? "sd-section"
 		: null;
 

--- a/web/src/pages/sql/[slug].astro
+++ b/web/src/pages/sql/[slug].astro
@@ -1,0 +1,247 @@
+---
+import { Code } from "astro:components";
+import LastVisited from "../../components/LastVisited.astro";
+import RecallRating from "../../components/RecallRating.astro";
+import { sqlProblems } from "../../data/sqlProblems";
+import Layout from "../../layouts/Layout.astro";
+import { withBase } from "../../lib/url";
+
+export function getStaticPaths() {
+	return sqlProblems.map((problem) => ({
+		params: { slug: problem.slug },
+		props: { problem },
+	}));
+}
+
+const { problem } = Astro.props;
+const categoryId = problem.category.toLowerCase().replace(/\s+&?\s*/g, "-");
+const runCommand = problem.dialect === "postgres"
+	? `brew services start postgresql@17\n./scripts/run_postgres_sql.sh ${problem.testFile}`
+	: `sqlite3 :memory: < ${problem.testFile}`;
+---
+
+<Layout title={`${problem.title} | Mental Gym`}>
+	<nav class="breadcrumb">
+		<a href={withBase("/problems#sql-section")}>Problems</a>
+		<span class="sep">›</span>
+		<a href={withBase(`/problems#sql-${categoryId}`)}>{problem.category}</a>
+		<span class="sep">›</span>
+		<span>{problem.title}</span>
+	</nav>
+
+	<section class="problem-header">
+		<p class="meta">{problem.id} · {problem.dialect === "postgres" ? "PostgreSQL" : "SQLite"}</p>
+		<h1>{problem.title}</h1>
+		<div class="tags">
+			<span class={`badge ${problem.difficulty.toLowerCase()}`}>{problem.difficulty}</span>
+			<span class="tag">{problem.category}</span>
+			{problem.tags.map((tag) => <span class="tag">{tag}</span>)}
+		</div>
+		<p class="summary">{problem.summary}</p>
+	</section>
+
+	<section class="panel">
+		<h2 class="section-title">Prompt</h2>
+		<p class="body-copy">{problem.prompt}</p>
+	</section>
+
+	<section class="panel local-run">
+		<h2 class="section-title">Run locally</h2>
+		<p class="body-copy">
+			The local test file loads the deterministic fixture, then runs the answer from its tracked <code>.sql</code> file inside a transaction that rolls back afterward.
+		</p>
+		<div class="code-wrapper">
+			<Code code={runCommand} lang="bash" theme="github-dark" />
+		</div>
+	</section>
+
+	<section class="panel">
+		<h2 class="section-title">Hints</h2>
+		<ul class="list">
+			{problem.hints.map((hint) => <li>{hint}</li>)}
+		</ul>
+	</section>
+
+	<details class="solution">
+		<summary>Reveal reference query</summary>
+		<div class="code-wrapper">
+			<Code code={problem.solution} lang="sql" theme="github-dark" />
+		</div>
+	</details>
+
+	<RecallRating
+		domain="sql"
+		slug={problem.slug}
+		title={problem.title}
+		difficulty={problem.difficulty}
+		group={problem.category}
+	/>
+	<LastVisited title={problem.title} kind="SQL" />
+</Layout>
+
+<style>
+	.breadcrumb {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		margin-bottom: 1.5rem;
+		color: var(--muted);
+		font: var(--fs-fine) var(--font-sans);
+		letter-spacing: 0.03em;
+		flex-wrap: wrap;
+	}
+
+	.breadcrumb a {
+		color: var(--muted);
+	}
+
+	.breadcrumb a:hover {
+		color: var(--accent);
+	}
+
+	.sep {
+		opacity: 0.4;
+	}
+
+	.problem-header {
+		display: grid;
+		gap: 0.75rem;
+		margin-bottom: 2rem;
+	}
+
+	.meta {
+		margin: 0;
+		color: var(--muted);
+		font: var(--fs-fine) var(--font-sans);
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+	}
+
+	h1 {
+		margin: 0;
+		font: 600 var(--fs-h1) var(--font-serif);
+		letter-spacing: 0.3px;
+	}
+
+	.summary {
+		max-width: 760px;
+		margin: 0;
+		color: var(--muted);
+		font-size: var(--fs-base);
+		line-height: 1.7;
+	}
+
+	.tags {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.badge,
+	.tag {
+		padding: 0.2rem 0.7rem;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-pill);
+		font: var(--fs-eyebrow) var(--font-sans);
+		letter-spacing: 0.04em;
+	}
+
+	.badge {
+		font-size: var(--fs-micro);
+		font-weight: 600;
+		text-transform: uppercase;
+	}
+
+	.badge.easy {
+		color: var(--status-easy);
+		border-color: color-mix(in srgb, var(--status-easy) 45%, transparent);
+		background: color-mix(in srgb, var(--status-easy) 12%, transparent);
+	}
+
+	.badge.medium {
+		color: var(--status-medium);
+		border-color: color-mix(in srgb, var(--status-medium) 45%, transparent);
+		background: var(--accent-soft);
+	}
+
+	.badge.hard {
+		color: var(--status-hard);
+		border-color: color-mix(in srgb, var(--status-hard) 45%, transparent);
+		background: color-mix(in srgb, var(--status-hard) 12%, transparent);
+	}
+
+	.tag {
+		color: var(--muted);
+	}
+
+	.panel,
+	.solution {
+		margin-bottom: 1rem;
+		padding: 1.5rem;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		background: var(--glass-surface);
+		backdrop-filter: blur(var(--glass-blur)) saturate(135%);
+		-webkit-backdrop-filter: blur(var(--glass-blur)) saturate(135%);
+		box-shadow: inset 0 1px 0 var(--glass-highlight), var(--shadow-sm);
+	}
+
+	.section-title {
+		margin: 0 0 1rem;
+		color: var(--muted);
+		font: 600 var(--fs-eyebrow) var(--font-sans);
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+	}
+
+	.body-copy {
+		max-width: var(--measure);
+		margin: 0;
+		color: var(--text);
+		font: var(--fs-base) / var(--lh-prose) var(--font-sans);
+	}
+
+	.local-run .body-copy {
+		margin-bottom: 1rem;
+		color: var(--muted);
+	}
+
+	.list {
+		margin: 0;
+		padding-left: var(--space-5);
+	}
+
+	.list li {
+		max-width: var(--measure);
+		margin-bottom: var(--space-2);
+		color: var(--text);
+		font: var(--fs-base) / var(--lh-prose) var(--font-sans);
+	}
+
+	.solution summary {
+		cursor: pointer;
+		color: var(--accent);
+		font: 600 var(--fs-eyebrow) var(--font-sans);
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+	}
+
+	.solution[open] summary {
+		margin-bottom: 1rem;
+	}
+
+	.code-wrapper :global(pre) {
+		margin: 0;
+		padding: 1.25rem;
+		overflow-x: auto;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		font-size: var(--fs-sm);
+		line-height: 1.6;
+	}
+
+	.code-wrapper :global(code) {
+		font-family: var(--font-mono);
+	}
+</style>

--- a/web/src/scripts/sr-export.ts
+++ b/web/src/scripts/sr-export.ts
@@ -14,7 +14,7 @@ function isReviewRecord(value: unknown): value is ReviewRecord {
   return (
     isObject(value) &&
     typeof value.problemKey === "string" &&
-    (value.domain === "algorithms" || value.domain === "ml") &&
+    (value.domain === "algorithms" || value.domain === "ml" || value.domain === "sql") &&
     typeof value.slug === "string" &&
     typeof value.title === "string" &&
     typeof value.difficulty === "string" &&
@@ -39,7 +39,7 @@ function isReviewEvent(value: unknown): value is ReviewEvent {
     typeof value.reviewedAt === "string" &&
     typeof value.reviewDate === "string" &&
     typeof value.problemKey === "string" &&
-    (value.domain === "algorithms" || value.domain === "ml") &&
+    (value.domain === "algorithms" || value.domain === "ml" || value.domain === "sql") &&
     typeof value.group === "string" &&
     (value.rating === 0 ||
       value.rating === 1 ||

--- a/web/src/scripts/sr-history.ts
+++ b/web/src/scripts/sr-history.ts
@@ -8,7 +8,7 @@ export interface HistoricalProgress {
   longestStreak: number;
   ratingCounts: Record<ReviewQuality, number>;
   dailyCounts: Map<string, number>;
-  domainCounts: { algorithms: number; ml: number };
+  domainCounts: { algorithms: number; ml: number; sql: number };
 }
 
 function addDays(date: string, days: number): string {
@@ -76,7 +76,7 @@ export function summarizeHistory(
     2: 0,
     3: 0,
   };
-  const domainCounts = { algorithms: 0, ml: 0 };
+  const domainCounts = { algorithms: 0, ml: 0, sql: 0 };
 
   for (const event of recent) {
     ratingCounts[event.rating] += 1;

--- a/web/src/scripts/sr-scheduler.ts
+++ b/web/src/scripts/sr-scheduler.ts
@@ -1,4 +1,4 @@
-import type { ReviewRecord, ReviewQuality, ReviewStatus } from "./sr-types";
+import type { ReviewDomain, ReviewRecord, ReviewQuality, ReviewStatus } from "./sr-types";
 
 export function localDateISO(date = new Date()): string {
   const year = date.getFullYear();
@@ -12,7 +12,7 @@ export function todayISO(): string {
 }
 
 export function createNewRecord(
-  domain: "algorithms" | "ml",
+  domain: ReviewDomain,
   slug: string,
   title: string,
   difficulty: string,

--- a/web/src/scripts/sr-stats.ts
+++ b/web/src/scripts/sr-stats.ts
@@ -76,7 +76,11 @@ export function summarizeProgress(
   return {
     ...summarize(records, today),
     domains: groupRecords(reviewed, today, (record) =>
-      record.domain === "algorithms" ? "Algorithms" : "Machine Learning"
+      record.domain === "algorithms"
+        ? "Algorithms"
+        : record.domain === "ml"
+          ? "Machine Learning"
+          : "SQL"
     ),
     topics: groupRecords(reviewed, today, (record) => record.group),
     dueRecords,

--- a/web/src/scripts/sr-types.ts
+++ b/web/src/scripts/sr-types.ts
@@ -1,9 +1,10 @@
 export type ReviewQuality = 0 | 1 | 2 | 3; // Again, Hard, Good, Easy
 export type ReviewStatus = "overdue" | "due" | "upcoming" | "new";
+export type ReviewDomain = "algorithms" | "ml" | "sql";
 
 export interface ReviewRecord {
   problemKey: string; // "algorithms:1-two-sum" or "ml:logistic-regression"
-  domain: "algorithms" | "ml";
+  domain: ReviewDomain;
   slug: string;
   title: string;
   difficulty: string;
@@ -23,7 +24,7 @@ export interface ReviewEvent {
   reviewedAt: string;
   reviewDate: string; // local "YYYY-MM-DD"
   problemKey: string;
-  domain: "algorithms" | "ml";
+  domain: ReviewDomain;
   group: string;
   rating: ReviewQuality;
   interval: number;

--- a/web/tests/sr-history.test.ts
+++ b/web/tests/sr-history.test.ts
@@ -72,5 +72,5 @@ test("summarizes recent activity, ratings, and domains", () => {
   assert.equal(stats.reviewsLast30Days, 3);
   assert.equal(stats.activeDaysLast30Days, 3);
   assert.deepEqual(stats.ratingCounts, { 0: 1, 1: 1, 2: 1, 3: 1 });
-  assert.deepEqual(stats.domainCounts, { algorithms: 2, ml: 2 });
+  assert.deepEqual(stats.domainCounts, { algorithms: 2, ml: 2, sql: 0 });
 });


### PR DESCRIPTION
## Summary
- add FourSum practice material
- add SQL exercise routes, local fixtures, and PostgreSQL/SQLite test support
- rework the Two Pointers note and add a guided Sliding Window note with linked practice and visualizations

## Verification
- `poetry run pytest`
- `npm run build` from `web/`
- FourSum canonical examples
- SQLite SQL exercise test
- PostgreSQL SQL exercise tests